### PR TITLE
Add Pipelock to Recommended Scanning Tools

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -182,6 +182,7 @@ The following open-source tools can be used to automate checklist verification:
 | [TruffleHog](https://github.com/trufflesecurity/trufflehog) | Secret scanning across repos and history | AST03, AST08 |
 | [Caterpillar](https://github.com/alice-dot-io/caterpillar) | Dynamic SAST for AI agents — continuous behavioral analysis | AST01, AST03, AST08 |
 | [Snyk](https://snyk.io/) | Dependency and supply chain scanning | AST02, AST07 |
+| [Pipelock](https://github.com/luckyPipewrench/pipelock) | Runtime network proxy — DLP, injection detection, tool poisoning, process sandbox (Landlock/seccomp) | AST01, AST03, AST04, AST06, AST07, AST08 |
 
 > No single tool covers all risks. A multi-tool pipeline combining static analysis, credential detection, and behavioral/dynamic analysis is recommended (see AST08).
 


### PR DESCRIPTION
Add Pipelock to the Recommended Scanning Tools table in the checklist.

Pipelock is an open-source runtime network proxy (Apache 2.0, Go) that sits between agentic applications and the internet, scanning HTTP/WebSocket/MCP traffic for secret exfiltration, prompt injection, tool poisoning, and SSRF. It also provides process sandboxing via Landlock and seccomp.

Covers AST01, AST03, AST04, AST06, AST07, AST08. First runtime proxy-based tool in the list — fills the runtime enforcement gap alongside the existing static analysis and credential detection tools.