### PR TITLE
Add pre-mutation receipt guidance for skill installers

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -31,6 +31,7 @@ A practical checklist for evaluating AI agent skills against the [OWASP Agentic 
 | 2.4 | Has a Software Bill of Materials (SBOM) been generated for the skill and its dependencies? | SBOM available in a standard format (CycloneDX, SPDX) |
 | 2.5 | Are repository configuration files (hooks, `.claude/settings.json`, env overrides) treated as executable code with trust gates? | Config files reviewed and approved; not auto-executed on clone/open |
 | 2.6 | Has the recursive dependency tree been scanned (not just top-level skill files)? | Deep scan report covering transitive dependencies |
+| 2.7 | Before installation or configuration mutation, does the installer emit a reviewable pre-mutation receipt? | Privacy-safe plan showing skills/agents selected, config files, hooks, MCP servers, env/network access, backups, external commands, approver, and `writes_started=false` before any write occurs |
 
 **Motivated by**: Claude Code CVE-2025-59536 (CVSS 8.7) — repo config files trigger RCE at project open before user dialog. ClawHub had no automated scanning at time of ClawHavoc.
 
@@ -193,6 +194,7 @@ The following open-source tools can be used to automate checklist verification:
 See [trust-boundary-model.md](./trust-boundary-model.md) for full framework.
 
 - [ ] **B1**: Are agent permissions explicitly declared and minimal before session start?
+- [ ] **B1**: Do skill/plugin installers produce a pre-mutation receipt before writing agent settings, hooks, MCP config, commands, or instruction files?
 - [ ] **B1**: Is developer context (MEMORY.md, issue content) sanitized before agent ingestion?
 - [ ] **B2**: Are all AI-generated dependency names validated against live registries?
 - [ ] **B2**: Is AI-generated code passing SAST before repository commit?

--- a/skill-development-guide.md
+++ b/skill-development-guide.md
@@ -206,6 +206,40 @@ class SecureStorage:
 - [ ] Documentation is complete
 - [ ] Signature keys are secure
 
+### Pre-Mutation Receipts for Installers and Hooks
+
+Skill and plugin installers increasingly wire several agent surfaces at once: settings files, hooks, commands, MCP servers, subagents, rules, and instruction files. Treat that installer as a supply-chain boundary, not as ordinary setup glue. Before the first write, emit a small receipt that can be reviewed, logged, or declined.
+
+A useful receipt is privacy-safe: it records what will be wired, not raw prompts, secrets, source code, full transcripts, or command output.
+
+```json
+{
+  "schema": "agent.install.plan.v1",
+  "installer": "example-skill-installer",
+  "target_platforms": ["Claude Code", "OpenClaw"],
+  "resources_planned": {
+    "skills": ["security-review"],
+    "hooks": ["PreToolUse: secret-file guard"],
+    "mcp_servers": ["github"],
+    "instruction_files": ["AGENTS.md"],
+    "settings_files": [".claude/settings.json"]
+  },
+  "external_commands_planned": ["npm install --package-lock-only"],
+  "network_after_install": ["api.github.com"],
+  "backups_planned": [".claude/settings.json.bak"],
+  "writes_started": false,
+  "next_safe_action": "review plan, then run installer with --apply"
+}
+```
+
+Implementation guidance:
+
+- Provide a `--plan` or `--dry-run` mode that exits before writing.
+- Show the effective mode (`plan`, `apply`, `repair`) and require an explicit transition to mutation.
+- Map every post-install change back to a planned write in the receipt.
+- Exclude secrets, environment dumps, raw prompts, transcripts, customer data, source code, and raw tool output.
+- Store the receipt with the skill inventory or approval record for later audit.
+
 ## Platform-Specific Guidelines
 
 ### OpenClaw Skills


### PR DESCRIPTION
## Summary

Adds a small, auditable pre-mutation receipt pattern for skill/plugin installers that wire agent settings, hooks, MCP servers, commands, instruction files, or subagents before the user has reviewed the exact changes.

## Why

Current AST10 guidance already treats repo config and hooks as executable supply-chain surfaces. A growing install pattern is one command that wires multiple agent surfaces at once. This PR makes the trust boundary explicit: installers should show a privacy-safe plan before the first write, then map any applied changes back to that plan.

## Changes

- Adds AST02 checklist item 2.7 for pre-mutation receipts.
- Adds a B1 boundary check for installer writes to agent settings/hooks/MCP/config/instructions.
- Adds a `Pre-Mutation Receipts for Installers and Hooks` section to the skill development guide with a compact JSON example and implementation notes.

## Validation

- `bash validate.sh` passed.
- `git diff --check` passed.

