### PR TITLE
Add USENIX Security 2026 measurement study as academic evidence for AST01

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,6 +663,7 @@ AST10 fills the gap between protocol-layer and model-layer security — a gap th
 ### Academic and Technical
 
 - **"Prompt Injection Attacks on Agentic Coding Assistants"** (arXiv:2601.17548)
+- **"Do Not Mention This to the User": Detecting and Understanding Malicious Agent Skills in the Wild** (arXiv:2602.06547, USENIX Security 2026) — large-scale measurement: 98,380 skills analyzed, 157 confirmed malicious, 632 vulnerabilities. https://arxiv.org/abs/2602.06547
 - **snyk-labs/toxicskills-goof** — Real malicious skill samples for scanner testing. https://github.com/snyk-labs/toxicskills-goof
 - **openclaw/openclaw Issue #10827** — Skill supply-chain security: provenance tracking and permission manifests proposal. https://github.com/openclaw/openclaw/issues/10827
 

--- a/ast01.md
+++ b/ast01.md
@@ -23,6 +23,7 @@ Unlike traditional malicious packages, malicious skills exploit both the *code l
 - Five of the top seven most-downloaded ClawHub skills at peak infection were confirmed malware.
 - Three lines of markdown in a `SKILL.md` file were sufficient to exfiltrate SSH keys (Snyk, Feb 2026).
 - Skills impersonating "Google," "Solana wallet tracker," "YouTube Summarize Pro," and "Polymarket Trader" — all designed to match high-demand searches.
+- A USENIX Security 2026 measurement study analyzed 98,380 skills across public marketplaces and confirmed 157 malicious skills carrying 632 vulnerabilities (avg. 4.03 per skill); 73.2% of malicious skills implemented shadow features hidden from the user, and 54.1% traced to a single publisher cluster (Liu et al., arXiv:2602.06547).
 
 ## Attack Scenarios
 
@@ -352,6 +353,7 @@ For confirmed malicious skill incidents:
 - [Snyk ToxicSkills](https://snyk.io/blog/toxicskills-malicious-ai-agent-skills-clawhub/)
 - [Check Point Research: Caught in the Hook](https://research.checkpoint.com/2026/rce-and-api-token-exfiltration-through-claude-code-project-files/)
 - [Antiy CERT: ClawHavoc Campaign Analysis](https://www.antiy.com/)
+- ["Do Not Mention This to the User": Detecting and Understanding Malicious Agent Skills in the Wild (USENIX Security 2026)](https://arxiv.org/abs/2602.06547)
 
 ---
 

--- a/index.md
+++ b/index.md
@@ -489,6 +489,7 @@ changelog:
 ### Academic and Technical
 
 - **"Prompt Injection Attacks on Agentic Coding Assistants"** (arXiv:2601.17548)
+- **"Do Not Mention This to the User": Detecting and Understanding Malicious Agent Skills in the Wild** (arXiv:2602.06547, USENIX Security 2026)
 - **snyk-labs/toxicskills-goof** — Real malicious skill samples for scanner testing.
 - **openclaw/openclaw Issue #10827** — Skill supply-chain security: provenance tracking and permission manifests proposal.
 


### PR DESCRIPTION
## Summary

Adds our peer-reviewed, large-scale measurement of malicious agent skills in the wild to AST01's Real-World Evidence and References, and to the Academic and Technical references in README.md / index.md.

**Paper:** "Do Not Mention This to the User": Detecting and Understanding Malicious Agent Skills in the Wild — accepted at the 35th USENIX Security Symposium (USENIX Security 2026). arXiv: https://arxiv.org/abs/2602.06547

**Why it strengthens AST01:** the study analyzed 98,380 skills across public marketplaces (skillsmp.com, skills.rest) and confirmed 157 malicious skills carrying 632 vulnerabilities (avg. 4.03 per skill). 73.2% of malicious skills implemented shadow features hidden from the user, and 54.1% traced to a single publisher cluster — empirical support for AST01's Critical rating and for the supply-chain concentration discussed in AST02. It is, to our knowledge, the first peer-reviewed wild measurement of this risk class, complementing the industry evidence (Snyk, Check Point, Antiy) already cited.

**Disclosure:** I am the first author of the paper.

## Changes
- `ast01.md`: one evidence bullet (Real-World Evidence) + one reference link (References)
- `README.md` and `index.md`: one entry each under *Academic and Technical*

## Validation
- `validate.sh` passes (all checks green)
- All added links resolve (HTTP 200)