### PR TITLE
Fix #19: mark API documentation as a proposed spec, remove dead API/dashboard links

### DIFF
--- a/api-documentation.md
+++ b/api-documentation.md
@@ -4,22 +4,26 @@ title: API Documentation
 tags: api, documentation, integration
 level: 2
 type: documentation
-pitch: Programmatic access to OWASP AST10 data and tools
-description: "RESTful API documentation for accessing OWASP AST10 security data, risk assessments, and integration tools."
+pitch: Proposed programmatic interface for OWASP AST10 data and tools (specification draft — not yet deployed)
+description: "Proposed RESTful API specification for OWASP AST10 security data, risk assessments, and integration tools. Design draft only — no live endpoints are deployed yet."
 ---
 
 # OWASP AST10 API Documentation
 
 The OWASP AST10 API provides programmatic access to security data, risk assessment tools, and integration capabilities for AI agent skill security.
 
+> **⚠️ Status: Proposed specification — not yet deployed.**
+> This page describes a *planned* API design published for community feedback. The base URL, dashboard, SDK packages, and support addresses below are **illustrative placeholders and are not live** — requests to them will fail. For example, `https://owasp.org/ast10/dashboard` returns **404** and the `https://api.owasp.org/ast10/v1` host does not resolve. No version of this API is currently running. Track implementation status in the [project issues](https://github.com/OWASP/www-project-agentic-skills-top-10/issues).
+
 ## Base URL
 ```
 https://api.owasp.org/ast10/v1
 ```
+*Placeholder host — not yet deployed; this address does not resolve.*
 
 ## Authentication
 
-All API requests require authentication using API keys. Get your API key from the [OWASP AST10 Dashboard](https://owasp.org/ast10/dashboard).
+Once the service is deployed, API requests will require authentication using API keys issued from an OWASP AST10 dashboard. **That dashboard does not exist yet** — the previously documented URL (`https://owasp.org/ast10/dashboard`) returns 404. The flow below is illustrative of the planned design.
 
 ```bash
 curl -H "Authorization: Bearer YOUR_API_KEY" \
@@ -294,9 +298,11 @@ When a scan completes, we'll POST to your callback URL:
 
 ### Rate Limits
 
+*Proposed tiers — illustrative only; no live service enforces these today.*
+
 - **Free Tier**: 100 requests/hour, 1,000/month
 - **Professional**: 1,000 requests/hour, 100,000/month
-- **Enterprise**: Unlimited (contact sales)
+- **Enterprise**: Unlimited
 
 Rate limit headers are included in all responses:
 ```
@@ -329,6 +335,8 @@ Common error codes:
 - `INTERNAL_ERROR`: Server error
 
 ### SDKs and Libraries
+
+*Proposed client libraries. These packages are **not yet published** — `@owasp/ast10-sdk` (npm), `ast10_sdk` (PyPI), and `ast10-sdk-go` do not exist on their registries yet. The snippets below illustrate the intended interface.*
 
 #### JavaScript/Node.js
 ```javascript
@@ -394,11 +402,12 @@ func main() {
 
 ### Support
 
-- **Documentation**: [Full API Reference](https://api.owasp.org/ast10/docs)
-- **Community Forum**: [OWASP AST10 Discussions](https://github.com/OWASP/www-project-agentic-skills-top-10/discussions)
+This is a proposed specification — there is no live API support channel yet. Use the project's GitHub repository for questions and to follow implementation:
+
 - **Issue Tracking**: [GitHub Issues](https://github.com/OWASP/www-project-agentic-skills-top-10/issues)
-- **Email Support**: api-support@owasp.org
+
+(The previously listed `https://api.owasp.org/ast10/docs` reference site and `api-support@owasp.org` mailbox are not deployed and do not work.)
 
 ---
 
-*API documentation is versioned. Current version: v1.1.0. Last updated: March 2026*
+*This is a draft API specification published for community review — not a released service. No version of this API is currently deployed.*


### PR DESCRIPTION
## Summary

Closes #19.

`api-documentation.md` documented a fully live REST API — base URL `api.owasp.org/ast10/v1`, a dashboard, `@owasp/ast10-sdk` packages, paid rate-limit tiers, and "contact sales" — none of which are deployed.

Verified dead:
- `https://owasp.org/ast10/dashboard` → **404**
- `https://api.owasp.org/ast10/v1/...` → host **does not resolve**
- `https://api.owasp.org/ast10/docs` → does not resolve
- `@owasp/ast10-sdk` on npm → **404**
- GitHub Discussions for this repo are **disabled**, so the old `/discussions` support link was also dead.

## Changes

- Add a prominent **"Proposed specification — not yet deployed"** status banner at the top.
- Mark the base URL, dashboard, SDK packages, docs site, and support email as illustrative placeholders that are not live.
- Drop the "contact sales" enterprise tier and the dead Discussions link.
- Reframe the footer from "Current version: v1.1.0, Last updated March 2026" to a draft-spec note.

The endpoint design itself is preserved as an illustrative draft — this PR only makes the page honest about deployment status so users stop hitting 404s expecting a working service.

## Validation

- `bash validate.sh` → all checks pass (no broken internal links, no artifacts).