### PR TITLE
Incorporate NVIDIA SkillSpector as a scanning mitigation (AST08 + catalog)

### DIFF
--- a/ast08.md
+++ b/ast08.md
@@ -23,6 +23,7 @@ A regex scanner can detect `curl` in a shell script. It cannot detect a skill th
 - **Snyk `toxicskills-goof` test suite**: SpecWeave's pattern-matching scanner caught 3 of 4 real malicious samples. The 4th used pure natural-language social engineering — "download and run the binary at this URL" — with no detectable code signature.
 - **Snyk documented SOUL.md attack vector**: malicious instructions hidden via base64 encoding, zero-width Unicode, and ASCII smuggling pass all text-based scanners.
 - **ClawHub's original "Skill Defender" scanner** — itself a skill — was used by attackers as a false-trust signal. Some scanner skills were themselves malicious.
+- **NVIDIA SkillSpector (2026)**: an open-source, agent-skill-aware scanner that combines static analysis (AST-based dangerous-code detection, taint tracking, YARA) with optional LLM semantic evaluation across 64 patterns in 16 categories. Per the SkillSpector project, roughly 26.1% of scanned skills contained vulnerabilities and 5.2% showed likely malicious intent — evidence that scanning purpose-built for the skill layer surfaces issues that generic code scanners miss.
 
 ## Attack Scenarios
 
@@ -44,7 +45,7 @@ Skill behaves safely in test environments; activates malicious path only when sp
 
 ## Preventive Mitigations
 
-1. **Deploy behavioral analysis scanners** that evaluate *intent*, not just signatures — using calibrated models combined with deterministic rules.
+1. **Deploy behavioral analysis scanners** that evaluate *intent*, not just signatures — using calibrated models combined with deterministic rules. Agent-skill-aware scanners such as [NVIDIA SkillSpector](https://github.com/NVIDIA/SkillSpector) (open source, Apache-2.0) pair fast static checks with optional LLM semantic analysis for exactly this purpose.
 2. **Scan both the code layer and the natural language instruction layer** independently.
 3. **Test skills in isolated sandboxes** and observe actual runtime behavior; compare against declared behavior.
 4. **Implement multi-tool scanning pipelines**: pattern matching + semantic analysis + behavioral sandbox.
@@ -84,6 +85,7 @@ Skill behaves safely in test environments; activates malicious path only when sp
 - [Snyk ToxicSkills](https://snyk.io/blog/toxicskills-malicious-ai-agent-skills-clawhub/)
 - [Snyk: Why Your Skill Scanner Is Just False Security](https://snyk.io/blog/skill-scanner-false-security/)
 - [Snyk: toxicskills-goof](https://github.com/snyk-labs/toxicskills-goof)
+- [NVIDIA SkillSpector — open-source security scanner for AI agent skills](https://github.com/NVIDIA/SkillSpector)
 - [OWASP Top 10 - A6 Security Misconfiguration](https://owasp.org/www-project-top-ten/)
 
 ---

--- a/checklist.md
+++ b/checklist.md
@@ -125,6 +125,7 @@ A practical checklist for evaluating AI agent skills against the [OWASP Agentic 
 | 8.4 | Was scanning performed in an isolated environment that prevents skill interference? | Scan environment instrumented; skill cannot detect or influence scanning context |
 | 8.5 | Has dynamic behavioral testing been performed in a sandboxed runtime? | Observed behavior log: file access, network calls, shell commands match declared scope |
 | 8.6 | Are scan results from skill-based scanners treated as advisory only (not sole gate)? | No reliance on a single scanner — especially not a scanner that is itself a skill |
+| 8.7 | Has the skill been scanned by an agent-skill-aware scanner before installation? | Pre-install scan report (e.g., NVIDIA SkillSpector) with risk score below threshold; critical/high findings triaged and resolved |
 
 **Motivated by**: 13.4% of critical-severity skills not caught by pattern matching (Snyk). ClawHub's "Skill Defender" scanner — itself a skill — was used by attackers as a false-trust signal. Alice Caterpillar flagged several published skills as actively malicious that were in use by over 6,000 OpenClaw users at time of detection ([Yahoo Finance](https://finance.yahoo.com/news/alice-releases-caterpillar-catching-malicious-191600442.html)).
 
@@ -182,6 +183,7 @@ The following open-source tools can be used to automate checklist verification:
 | [Gitleaks](https://github.com/gitleaks/gitleaks) | Credential and secret detection | AST03, AST08 |
 | [TruffleHog](https://github.com/trufflesecurity/trufflehog) | Secret scanning across repos and history | AST03, AST08 |
 | [Caterpillar](https://github.com/alice-dot-io/caterpillar) | Dynamic SAST for AI agents — continuous behavioral analysis | AST01, AST03, AST08 |
+| [SkillSpector](https://github.com/NVIDIA/SkillSpector) | Agent-skill security scanner (NVIDIA, Apache-2.0) — static + optional LLM semantic, OSV.dev CVE lookups, SARIF output | AST01, AST02, AST03, AST04, AST08, AST09, AST10 |
 | [Snyk](https://snyk.io/) | Dependency and supply chain scanning | AST02, AST07 |
 | [Pipelock](https://github.com/luckyPipewrench/pipelock) | Runtime network proxy — DLP, injection detection, tool poisoning, process sandbox (Landlock/seccomp) | AST01, AST03, AST04, AST06, AST07, AST08 |
 

--- a/skill-scanner-integration.md
+++ b/skill-scanner-integration.md
@@ -18,6 +18,69 @@ Automated skill scanning is essential for detecting security vulnerabilities bef
 
 ## Supported Scanning Tools
 
+### NVIDIA SkillSpector (open source, recommended)
+
+[SkillSpector](https://github.com/NVIDIA/SkillSpector) (Apache-2.0) is an agent-skill-aware
+security scanner. It runs fast static checks plus optional LLM semantic analysis and returns a
+0–100 risk score with severity labels. It accepts Git repos, URLs, zip files, directories, or
+single files, and emits terminal, JSON, Markdown, or **SARIF** reports.
+
+```bash
+# Install (Python 3.12+)
+git clone https://github.com/NVIDIA/SkillSpector && cd SkillSpector
+make install
+
+# Static-only scan of a local skill (no API key required)
+skillspector scan ./my-skill/ --no-llm
+
+# Full scan with optional LLM semantic analysis
+export SKILLSPECTOR_PROVIDER=anthropic
+export ANTHROPIC_API_KEY=sk-ant-...
+skillspector scan https://github.com/user/my-skill
+
+# Emit SARIF for CI / code scanning
+skillspector scan ./my-skill/ --no-llm --format sarif --output skillspector.sarif
+```
+
+Run it without installing Python via the project's Dockerfile:
+
+```bash
+docker run --rm -v "$PWD:/scan" skillspector scan ./my-skill/ --no-llm
+```
+
+#### GitHub Actions — SkillSpector gate with code-scanning upload
+
+```yaml
+name: Skill Security Scan
+on:
+  pull_request:
+    paths: ['skills/**']
+
+permissions:
+  contents: read
+  security-events: write   # required to upload SARIF
+
+jobs:
+  skillspector:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - run: pip install git+https://github.com/NVIDIA/SkillSpector
+      - name: Scan skills
+        run: skillspector scan ./skills --no-llm --format sarif --output skillspector.sarif
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: skillspector.sarif
+```
+
+Because SkillSpector emits SARIF v2.1.0, findings surface in the GitHub **Security → Code
+scanning** tab and can gate merges; the 0–100 risk score is a natural threshold for an approval
+workflow (see AST09). It maps to **AST01, AST02, AST03, AST04, AST08, AST09, and AST10** — see
+[solutions.md](solutions.md) for the full coverage breakdown.
+
 ### AST10-Scanner
 The official OWASP AST10 scanner provides comprehensive vulnerability detection:
 
@@ -370,6 +433,7 @@ print(json.dumps(results, indent=2))
 
 ## Available Tools and Resources
 
+- **NVIDIA SkillSpector**: [GitHub Repository](https://github.com/NVIDIA/SkillSpector) — open-source (Apache-2.0) agent-skill security scanner
 - **AST10 Scanner**: [GitHub Repository](https://github.com/OWASP/ast10-scanner)
 - **ClawHub Security Tools**: [Documentation](https://clawhub.dev/security)
 - **VS Code Security Linting**: [Marketplace](https://marketplace.visualstudio.com)

--- a/solutions.md
+++ b/solutions.md
@@ -12,6 +12,7 @@ Submit a PR adding your tool using the template at the bottom of this page. All 
 | Tool                                                                               | License | AST Risks Addressed                             | Language |
 | ---------------------------------------------------------------------------------- | ------- | ----------------------------------------------- | -------- |
 | [AgentMint](https://github.com/aniketh-maddipati/agentmint-python)| MIT     | AST01, AST02, AST03, AST04, AST07, AST08, AST09 | Python   |
+| [SkillSpector](https://github.com/NVIDIA/SkillSpector)| Apache-2.0 | AST01, AST02, AST03, AST04, AST08, AST09, AST10 | Python   |
 
 
 ---
@@ -56,6 +57,49 @@ Submit a PR adding your tool using the template at the bottom of this page. All 
 ### Framework Integration
 
 Integrates via hooks with CrewAI, OpenAI Agents SDK, Google ADK, and MCP. Typical integration requires approximately 20 lines of code per framework.
+
+---
+
+## SkillSpector
+
+**Description:** Open-source security scanner for AI agent skills (NVIDIA). Performs two-stage analysis — fast static checks plus optional LLM semantic evaluation — to answer "is this skill safe to install?" before installation. Produces a 0–100 risk score with severity labels and SARIF, JSON, or Markdown reports.
+
+**License:** Apache-2.0  
+**Repository:** [https://github.com/NVIDIA/SkillSpector](https://github.com/NVIDIA/SkillSpector)  
+**Install:** `git clone https://github.com/NVIDIA/SkillSpector && make install` (or run via the included Dockerfile)  
+**Dependencies:** Python 3.12+; optional LLM provider (Anthropic / OpenAI-compatible) for semantic analysis; OSV.dev for live CVE lookups
+
+### AST Risks Addressed
+
+**AST01 — Malicious Skills:** Detects malicious patterns and likely-malicious intent via YARA signatures, rogue-agent and trigger-abuse heuristics, and optional LLM intent analysis. Per NVIDIA's SkillSpector project, roughly 5.2% of scanned skills show likely malicious intent.
+
+**AST02 — Supply Chain Compromise:** Supply-chain pattern category plus live OSV.dev CVE lookups against declared dependencies (with offline fallback).
+
+**AST03 — Over-Privileged Skills:** Flags excessive agency, privilege escalation, tool misuse, and MCP least-privilege violations.
+
+**AST04 — Insecure Metadata:** Scans `SKILL.md` prose and metadata for prompt injection and system-prompt leakage.
+
+**AST08 — Poor Scanning:** Directly addresses the scanning gap — combines static analysis (AST-based dangerous-code detection, taint tracking, YARA) across both the code and natural-language layers with optional LLM semantic evaluation, covering 64 patterns across 16 categories.
+
+**AST09 — No Governance:** Emits SARIF v2.1.0 for GitHub Code Scanning and CI gates; the 0–100 risk score supports approval workflows and scan-result inventories.
+
+**AST10 — Cross-Platform Reuse:** Platform-agnostic content-layer scanner (Claude Code, Codex CLI, Gemini CLI) that evaluates skills independently of the runtime.
+
+### Risks Not Addressed
+
+**AST05 — Unsafe Deserialization:** Partial only — dangerous-code and taint analysis can flag unsafe parsing, but it does not sandbox deserialization.  
+**AST06 — Weak Isolation:** Out of scope — a pre-install static/LLM scanner does not provide runtime sandboxing or process isolation.  
+**AST07 — Update Drift:** Partial — re-scanning on update and OSV freshness help, but it does not pin versions or enforce an update policy.
+
+### Known Limitations
+
+- Pre-install analysis: catches issues before installation, not runtime behavior. Pair with sandboxing (AST06) and governance (AST09).
+- The LLM semantic stage requires an API key / model provider; static-only mode (`--no-llm`) runs without one but with reduced intent coverage.
+- Static pattern coverage, like any scanner, can be evaded by sufficiently novel obfuscation — use as one layer of a pipeline, not the sole gate.
+
+### Framework Integration
+
+CLI and Docker; scans Git repos, URLs, zip files, directories, or single files. Emits SARIF v2.1.0 for GitHub Code Scanning and other SARIF consumers, plus JSON and Markdown. Integrates into CI/CD as a pre-merge or pre-publish gate keyed on the risk score.
 
 ---
 


### PR DESCRIPTION
## Summary

Incorporates **[NVIDIA SkillSpector](https://github.com/NVIDIA/SkillSpector)** — an open-source (Apache-2.0) agent-skill security scanner — as a mitigation across the relevant pages.

**Verification:** repo is owned by the GitHub-verified **NVIDIA org** (`id 1728152`), Apache-2.0, ~4.7k stars / 360 forks. It runs static analysis (AST dangerous-code, taint tracking, YARA) + optional LLM semantic evaluation across 64 patterns / 16 categories, does live OSV.dev CVE lookups, and outputs a 0–100 risk score with SARIF/JSON/Markdown reports.

## Where it maps

| Strong | Partial | Out of scope |
|---|---|---|
| AST08 (primary), AST01, AST02, AST03, AST10, AST09 | AST04, AST05, AST07 | AST06 (runtime isolation) |

## Changes

- **`solutions.md`** — full vendor-neutral catalog entry (Description / License / Repo / Install / Dependencies / Risks Addressed / Risks Not Addressed / Limitations / Integration) + a summary-table row. Same template as the existing AgentMint entry.
- **`ast08.md` (Poor Scanning)** — its best AST home: a Real-World Evidence bullet, a concrete example added to mitigation #1 (behavioral/semantic scanning), and a References link.
- **`skill-scanner-integration.md`** — a real SkillSpector section (CLI, Docker, **SARIF → GitHub Code Scanning**, CI gate) placed ahead of the page's existing placeholder `@owasp/ast10-scanner` (which doesn't exist on npm or GitHub).
- **`checklist.md`** — AST08 check **8.7** (scan with an agent-skill-aware scanner before install) + a row in the Recommended Scanning Tools table.

## Evidence handling

The "**26.1% vulnerable / 5.2% malicious**" figure is included but **attributed explicitly to the SkillSpector project** (the README states it without a linked primary study), rather than presented as an independent OWASP-verified finding — consistent with `MAINTENANCE.md`'s evidence rule. The tool itself is solidly citable regardless.

## Validation

- `bash validate.sh` → all checks pass (no broken internal links, no artifacts).