### PR TITLE
Fix stale scanner and project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,7 +654,7 @@ AST10 fills the gap between protocol-layer and model-layer security — a gap th
 ### Standards and Frameworks
 - **OWASP AIVSS Project** (2025) — https://aivss.owasp.org
 - **OWASP LLM Top 10** (2025) — https://owasp.org/www-project-top-10-for-large-language-model-applications/
-- **OWASP Agentic AI Top 10** (Dec 2025) — https://owasp.org/www-project-agentic-ai-threats/
+- **OWASP Top 10 for Agentic Applications** (2026) — https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/
 - **NIST AI RMF** — https://airc.nist.gov/
 - **ISO/IEC 42001** (AI Management System) — https://www.iso.org/standard/81230.html
 - **EU AI Act** (enforced Aug 2026) — https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689

--- a/community-contribution.md
+++ b/community-contribution.md
@@ -85,17 +85,17 @@ git push origin improve/documentation
 
 **Featured Tools**:
 
-#### AST10 Scanner
+#### Skill scanner rule contributions
 ```bash
-# Contribute to scanner development
-git clone https://github.com/OWASP/ast10-scanner
-cd ast10-scanner
+# Pick an active scanner project used by this guide
+git clone https://github.com/NVIDIA/SkillSpector
+cd SkillSpector
 
 # Add new detection rules
-vim rules/ast01_detection.py
+vim src/skillspector/nodes/analyzers/static_patterns_prompt_injection.py
 
 # Add test cases
-vim tests/test_ast01.py
+vim tests/nodes/analyzers/test_static_patterns.py
 
 # Submit pull request
 ```
@@ -364,7 +364,7 @@ Contributing significantly can lead to:
 
 **Questions?**
 - Check [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines
-- Join [GitHub Discussions](https://github.com/OWASP/www-project-agentic-skills-top-10/discussions)
+- Open a [GitHub issue](https://github.com/OWASP/www-project-agentic-skills-top-10/issues)
 - Email: contributors@owasp.org
 
 Welcome to the OWASP AST10 community! 🛡️

--- a/index.md
+++ b/index.md
@@ -503,7 +503,7 @@ changelog:
 ## Resources
 
 - **GitHub**: [github.com/OWASP/www-project-agentic-skills-top-10](https://github.com/OWASP/www-project-agentic-skills-top-10)
-- **OWASP Project Page**: [owasp.org/projects/agentic-skills-top-10](https://owasp.org/projects/agentic-skills-top-10)
+- **OWASP Project Page**: [owasp.org/www-project-agentic-skills-top-10](https://owasp.org/www-project-agentic-skills-top-10/)
 - **Full Risk Documentation**: [Visual Top 10 Overview](/www-project-agentic-skills-top-10/top10)
 - **Project Proposal**: [proposal.md](proposal.md)
 - **Security Assessment Checklist**: [checklist.md](checklist.md)

--- a/proposal.md
+++ b/proposal.md
@@ -21,7 +21,7 @@
 ## Project Links (Planned)
 
 - **GitHub**: [github.com/OWASP/www-project-agentic-skills-top-10](https://github.com/OWASP/www-project-agentic-skills-top-10)
-- **OWASP Page**: [owasp.org/projects/agentic-skills-top-10](https://owasp.org/projects/agentic-skills-top-10)
+- **OWASP Page**: [owasp.org/www-project-agentic-skills-top-10](https://owasp.org/www-project-agentic-skills-top-10/)
 
 
 ## Goals & Success Metrics

--- a/skill-scanner-integration.md
+++ b/skill-scanner-integration.md
@@ -81,26 +81,11 @@ scanning** tab and can gate merges; the 0–100 risk score is a natural threshol
 workflow (see AST09). It maps to **AST01, AST02, AST03, AST04, AST08, AST09, and AST10** — see
 [solutions.md](solutions.md) for the full coverage breakdown.
 
-### AST10-Scanner
-The official OWASP AST10 scanner provides comprehensive vulnerability detection:
+### OWASP AST10 Scanner Status
 
-```bash
-# Install AST10 Scanner
-npm install -g @owasp/ast10-scanner
-
-# Scan a skill file
-ast10-scan skill.yaml --output report.json
-
-# Scan with custom rules
-ast10-scan skill.yaml --rules custom-rules.json --severity high
-```
-
-#### Features
-- AST10 risk pattern detection
-- Permission analysis
-- Code injection vulnerability scanning
-- Supply chain risk assessment
-- MAESTRO framework compliance checking
+An OWASP-maintained `@owasp/ast10-scanner` package is not currently published.
+Until one exists, use the open-source scanners listed above and map their
+findings to the AST01-AST10 taxonomy in reports and CI output.
 
 ### Platform-Specific Scanners
 
@@ -159,33 +144,24 @@ jobs:
   security-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          node-version: '18'
+          python-version: '3.12'
 
-      - name: Install AST10 Scanner
-        run: npm install -g @owasp/ast10-scanner
+      - name: Install SkillSpector
+        run: pip install git+https://github.com/NVIDIA/SkillSpector
 
       - name: Scan Skills
-        run: |
-          find skills -name "*.md" -o -name "*.json" -o -name "*.yaml" | \
-          xargs ast10-scan --output security-report.json
+        run: skillspector scan ./skills --no-llm --format sarif --output skillspector.sarif
 
       - name: Upload Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: security-report
-          path: security-report.json
-
-      - name: Fail on High Severity
-        run: |
-          if jq '.vulnerabilities[] | select(.severity == "high")' security-report.json | grep -q .; then
-            echo "High severity vulnerabilities found!"
-            exit 1
-          fi
+          path: skillspector.sarif
 ```
 
 #### GitLab CI Example
@@ -195,11 +171,11 @@ stages:
 
 security_scan:
   stage: security
-  image: node:18
+  image: python:3.12
   before_script:
-    - npm install -g @owasp/ast10-scanner
+    - pip install git+https://github.com/NVIDIA/SkillSpector
   script:
-    - find skills -name "*.md" -o -name "*.json" -o -name "*.yaml" | xargs ast10-scan --gitlab-report
+    - skillspector scan ./skills --no-llm --format sarif --output gl-sast-report.json
   artifacts:
     reports:
       sast: gl-sast-report.json
@@ -216,12 +192,13 @@ pip install pre-commit
 
 # Create .pre-commit-config.yaml
 repos:
-  - repo: https://github.com/owasp/ast10-scanner
-    rev: v1.0.0
+  - repo: local
     hooks:
-      - id: ast10-scan
+      - id: skillspector-scan
+        name: SkillSpector scan
+        entry: skillspector scan . --no-llm
+        language: system
         files: \.(md|json|yaml)$
-        args: [--severity, high]
 ```
 
 ### Registry Integration
@@ -434,16 +411,14 @@ print(json.dumps(results, indent=2))
 ## Available Tools and Resources
 
 - **NVIDIA SkillSpector**: [GitHub Repository](https://github.com/NVIDIA/SkillSpector) — open-source (Apache-2.0) agent-skill security scanner
-- **AST10 Scanner**: [GitHub Repository](https://github.com/OWASP/ast10-scanner)
-- **ClawHub Security Tools**: [Documentation](https://clawhub.dev/security)
 - **VS Code Security Linting**: [Marketplace](https://marketplace.visualstudio.com)
 
 ## Contributing
 
 To contribute new scanning rules or improve existing scanners:
 
-1. Fork the AST10 Scanner repository
-2. Add your rule or improvement
+1. Fork the scanner repository you use
+2. Add your rule, detector, or report-mapping improvement
 3. Submit a pull request with test cases
 4. Ensure backward compatibility
 


### PR DESCRIPTION
## Summary
- Replace dead placeholder `@owasp/ast10-scanner` install, CI, and pre-commit examples with the already documented NVIDIA SkillSpector scanner path.
- Update stale OWASP project and Agentic Applications links to live OWASP pages.
- Replace the disabled GitHub Discussions pointer with the repository issues page.

## Validation
- `bash validate.sh` passed. Jekyll was skipped because it is not installed locally.
- `npx --yes markdown-link-check skill-scanner-integration.md community-contribution.md proposal.md --quiet` passed.
- Verified the new OWASP, GenAI OWASP, GitHub Actions, SkillSpector, and repository issue links.
- `npm view @owasp/ast10-scanner version --json` returns npm 404.
- `gh api repos/OWASP/ast10-scanner` returns GitHub 404.
- `git diff --check` passed.

I also ran `npx --yes markdown-link-check README.md index.md --quiet`. It still reports pre-existing target-owned link-check issues for the mailing-list `mailto:`, LinkedIn, and root-relative site links when checked from a local clone; this PR does not introduce those failures.
