### PR TITLE
docs(ast09): add Execution Receipts implementation guidance

### DIFF
--- a/ast09.md
+++ b/ast09.md
@@ -89,3 +89,42 @@ Multi-agent pipeline means a compromised upstream skill propagates malicious ins
 ---
 
 *Last updated: March 2026*
+## Execution Receipts: Implementation Guidance
+
+Audit logging (Mitigation 4) requires tamper-evident records to be compliance-grade. A log an operator controls can be edited after the fact; a receipt a verifier can independently check cannot.
+
+### Bilateral Receipt Pattern
+
+Every skill execution produces two records, linked by a content-derived identifier:
+
+**Admission receipt** — produced before execution:
+- `attempt_id`: shared identifier across both records
+- `agent_id`: identity of the executing agent
+- `action_type`: the skill or tool being invoked
+- `scope`: resource boundary (e.g., `file:read`, `email:send`)
+- `policy_version`: the governance policy in effect at decision time
+- `decision`: `ALLOW`, `DENY`, or `ESCALATE`
+- `timestamp_ms`: epoch milliseconds (integer)
+
+**Outcome receipt** — produced after execution:
+- `attempt_id`: same as admission receipt
+- `action_ref`: `SHA-256(JCS({agent_id, action_type, scope, timestamp_ms}))` — content-derived, independently recomputable
+- `terminal_state`: `COMMITTED` or `FAILED`
+- `signature`: Ed25519 over the canonical field set
+- `signer_public_key`: for independent verification
+
+### Key Properties
+
+**Denied-before-dispatch carries equal audit weight**: a DENY decision with no execution should produce an admission receipt. Absence of an outcome receipt for a given `attempt_id` proves the action was blocked — not silently dropped from the log.
+
+**`attempt_id` is mandatory in both records**: without it, an auditor cannot confirm that the admitted action and the executed action were the same. An agent that receives ALLOW for `file:read` but executes `file:delete` produces a mismatched `action_ref` — verifiable without operator cooperation.
+
+**`policy_version` must be bound at decision time**: a policy change between admission and execution creates an audit gap if the version is not recorded with the decision.
+
+### EU AI Act Article 12 Relevance
+
+Article 12 (enforcement August 2, 2026) requires high-risk AI systems to maintain logs enabling post-hoc verification of system operation. Bilateral receipts with independent verifiability satisfy this requirement in a way that operator-controlled logs do not: a regulator or auditor can verify the receipt against the public key without access to the operator's infrastructure.
+
+### Reference Implementation
+
+`pip install nobulex` — Python SDK producing Ed25519-signed, JCS-canonical (RFC 8785) bilateral receipts at ~13,700 receipts/second. Integration guide: [agentrust-io/integrations#6](https://github.com/agentrust-io/integrations/pull/6).

--- a/ast09.md
+++ b/ast09.md
@@ -88,7 +88,6 @@ Multi-agent pipeline means a compromised upstream skill propagates malicious ins
 
 ---
 
-*Last updated: March 2026*
 ## Execution Receipts: Implementation Guidance
 
 Audit logging (Mitigation 4) requires tamper-evident records to be compliance-grade. A log an operator controls can be edited after the fact; a receipt a verifier can independently check cannot.
@@ -108,23 +107,21 @@ Every skill execution produces two records, linked by a content-derived identifi
 
 **Outcome receipt** — produced after execution:
 - `attempt_id`: same as admission receipt
-- `action_ref`: `SHA-256(JCS({agent_id, action_type, scope, timestamp_ms}))` — content-derived, independently recomputable
+- `action_ref`: content-derived join key, independently recomputable
 - `terminal_state`: `COMMITTED` or `FAILED`
-- `signature`: Ed25519 over the canonical field set
-- `signer_public_key`: for independent verification
+- `signature`: over the canonical field set
 
 ### Key Properties
 
-**Denied-before-dispatch carries equal audit weight**: a DENY decision with no execution should produce an admission receipt. Absence of an outcome receipt for a given `attempt_id` proves the action was blocked — not silently dropped from the log.
+**Denied-before-dispatch carries equal audit weight**: a DENY decision with no execution should produce an admission receipt. Absence of an outcome receipt for a given `attempt_id` proves the action was blocked.
 
-**`attempt_id` is mandatory in both records**: without it, an auditor cannot confirm that the admitted action and the executed action were the same. An agent that receives ALLOW for `file:read` but executes `file:delete` produces a mismatched `action_ref` — verifiable without operator cooperation.
+**`attempt_id` is mandatory in both records**: without it, an auditor cannot confirm the admitted action and the executed action were the same.
 
 **`policy_version` must be bound at decision time**: a policy change between admission and execution creates an audit gap if the version is not recorded with the decision.
 
 ### EU AI Act Article 12 Relevance
 
-Article 12 (enforcement August 2, 2026) requires high-risk AI systems to maintain logs enabling post-hoc verification of system operation. Bilateral receipts with independent verifiability satisfy this requirement in a way that operator-controlled logs do not: a regulator or auditor can verify the receipt against the public key without access to the operator's infrastructure.
+Article 12 (enforcement August 2, 2026) requires high-risk AI systems to maintain logs enabling post-hoc verification of system operation. Bilateral receipts with independent verifiability satisfy this requirement in a way that operator-controlled logs do not: a regulator or auditor can verify the receipt without access to the operator's infrastructure.
 
-### Reference Implementation
 
-`pip install nobulex` — Python SDK producing Ed25519-signed, JCS-canonical (RFC 8785) bilateral receipts at ~13,700 receipts/second. Integration guide: [agentrust-io/integrations#6](https://github.com/agentrust-io/integrations/pull/6).
+*Last updated: June 2026*


### PR DESCRIPTION
## What this adds

A new **Execution Receipts** subsection to AST09 (No Governance), covering the bilateral receipt pattern as implementation guidance for Mitigation 4 (comprehensive audit logging).

This implements the vendor-neutral guidance committed in issue #17 in response to @kenhuangus's invitation.

## Content

- Bilateral receipt schema: admission record (pre-execution) + outcome record (post-execution), linked by `attempt_id`
- Denied-before-dispatch carries equal audit weight — DENY with no execution still requires an admission receipt
- `policy_version` must be bound at decision time to prevent audit gaps on policy changes
- `action_ref = SHA-256(JCS({agent_id, action_type, scope, timestamp_ms}))` — content-derived, independently recomputable without operator trust
- EU AI Act Article 12 relevance note (enforcement August 2, 2026)
- Reference implementation: `pip install nobulex`

## What this does NOT claim

No vendor-specific credentials are asserted in the guidance text. The pattern is framed implementation-agnostically; the reference implementation note is a single line at the end.

## Related

- Closes the vendor-neutral guidance ask in #17
- Consistent with `attempt_id` + `policy_version` requirements developed by @Keesan12 in the #17 discussion