### PR TITLE
fix(pages): correct baseurl in custom workflow; add manual system-build trigger

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,6 +28,7 @@ jobs:
           bundler-cache: true
 
       - name: Setup Pages
+        id: pages
         uses: actions/configure-pages@v4
 
       - name: Build with Jekyll

--- a/.github/workflows/trigger-system-deploy.yml
+++ b/.github/workflows/trigger-system-deploy.yml
@@ -1,6 +1,9 @@
 name: Trigger system Pages build
 on:
   workflow_dispatch:
+permissions:
+  pages: write
+  id-token: write
 jobs:
   trigger:
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger-system-deploy.yml
+++ b/.github/workflows/trigger-system-deploy.yml
@@ -1,0 +1,11 @@
+name: Trigger system Pages build
+on:
+  workflow_dispatch:
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request Pages build
+        run: gh api repos/${{ github.repository }}/pages/builds -X POST
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes broken links on the live site (e.g. `/ast05.html` instead of `/www-project-agentic-skills-top-10/ast05.html`) caused by a race condition between two competing GitHub Pages deployments.

**Root cause:** `configure-pages@v4` in `pages.yml` was missing `id: pages`, so `${{ steps.pages.outputs.base_path }}` evaluated to `""` and Jekyll built with `--baseurl ""`. Two workflows both deploy to Pages on every push — whichever finishes last wins. For three months the system `pages-build-deployment` finished last (serving correct output), but the growing codebase slowed the custom Ruby build enough to flip the race in late June.

Proved with the June 24 build artifacts:
- `pages.yml` artifact ([run 28072026216](https://github.com/OWASP/www-project-agentic-skills-top-10/actions/runs/28072026216)): `href="/ast05.html"` ❌ — finished at `02:59:56`
- `pages-build-deployment` artifact ([run 28072026287](https://github.com/OWASP/www-project-agentic-skills-top-10/actions/runs/28072026287)): `href="/www-project-agentic-skills-top-10/ast05.html"` ✅ — finished at `02:59:54`

Changes:
- **`.github/workflows/pages.yml`** — add `id: pages` to the `configure-pages@v4` step so `steps.pages.outputs.base_path` resolves to `/www-project-agentic-skills-top-10`
- **`.github/workflows/trigger-system-deploy.yml`** — new `workflow_dispatch`-only workflow that POSTs to the Pages build API, so the system build can be triggered manually from the Actions UI without a dummy commit

## Validation

- Confirmed the race condition and broken output by downloading both unexpired June 24 artifacts and diffing the `href` values in `index.html`
- `id: pages` is the documented fix for `configure-pages@v4` per the [actions/configure-pages README](https://github.com/actions/configure-pages)