### PR TITLE
fix(index): add markdown="1" to table div for kramdown rendering

### DIFF
--- a/index.md
+++ b/index.md
@@ -203,7 +203,7 @@ Each of the 10 risks is documented in a separate file. Click on the risk name to
 
 > 📊 **Prefer a visual map?** See the **[Top 10 Visual Overview](/www-project-agentic-skills-top-10/top10)** — a skill-lifecycle diagram plus a colour-coded card for every risk.
 
-<div class="ast-summary-table" style="overflow-x:auto">
+<div class="ast-summary-table" markdown="1" style="overflow-x:auto">
 
 | # | Risk | Severity | Key Mitigation | Real-World Evidence |
 |---|------|----------|----------------|---------------------|


### PR DESCRIPTION
## Summary

- Adds `markdown="1"` attribute to the summary table `<div>` so kramdown correctly renders the Markdown table inside it
- Fixes broken table rendering on the OWASP GitHub Pages site

## Test plan

- [ ] Verify the summary table renders correctly on the GitHub Pages site after merge