### PR TITLE
docs: proposal for AST-mapped fixture corpus (per #8)

### DIFF
--- a/proposals/ast-fixture-corpus/proposal.md
+++ b/proposals/ast-fixture-corpus/proposal.md
@@ -1,0 +1,75 @@
+# Proposal: AST-mapped fixture corpus
+
+Status: proposal for discussion, per the shape outlined by @kenhuangus in #8.
+Nothing here is normative. The intent is a concrete starting point maintainers
+can review, cut down, or reshape, not a conformance program.
+
+## Motivation
+
+Independent implementations of the AST guidance currently validate against
+their own private test data. A small corpus of portable vectors, each mapped
+to an AST control and carrying both a threat scenario and its safe-case
+counterpart, would let any implementation check itself against shared
+expectations. The discussion in #8 established the demand; this file proposes
+the minimal shape.
+
+## Vector fields
+
+Each vector is one JSON document with the following fields.
+
+| Field | Meaning |
+| --- | --- |
+| `vectorId` | Stable identifier for the vector. |
+| `astControl` | The AST control the vector exercises, for example `AST09`. |
+| `threatScenario` | One or two sentences naming the failure mode, in the language the AST page uses. |
+| `request` | The action envelope under test. Runtime-specific request fields may appear under `request.example_extensions` and are illustrative only, never normative. |
+| `authorityContext` | Optional. Policy version, delegation state, or other authority inputs the enforcement point consumes. |
+| `expectedEnforcementPoint` | Where in the lifecycle the control acts, for example `pre-dispatch admission gate`. |
+| `expectedDecision` | The decision the scenario must produce, for example `DENY`. |
+| `expectedAuditArtifact` | The record or check outcome that evidences the decision, described concretely enough for a verifier to reproduce. |
+| `safeCase` | The counterpart request that must succeed, with its own expected decision and artifact. |
+
+## Declared preimages
+
+Audit artifacts that use a content-derived identifier MUST declare
+`preimage_fields`: the exact field list, in canonical order, that the
+identifier is computed over. Different conforming implementations derive
+identifiers over different field sets (see the discussion on #45, where a
+five-field derivation and a four-field derivation are both consistent with
+the AST09 wording). A verifier can only recompute an identifier it knows the
+preimage of. Declaring the preimage per vector keeps fixtures from different
+implementations mutually checkable without guesswork.
+
+Canonicalization for the illustrative vectors below is RFC 8785 (JCS) with
+`timestamp_ms` as an epoch-millisecond integer. Serializing timestamps as
+RFC 3339 strings produces different canonical bytes and is the most common
+cross-implementation divergence observed in this pattern.
+
+## Illustrative vectors
+
+Two AST09 vectors accompany this file. All identifiers in them recompute
+under the Python `rfc8785` reference implementation.
+
+1. `vector-ast09-deny-network-egress.json`: a skill attempts egress to a
+   host outside its allowlist. Expected: DENY at the pre-dispatch admission
+   gate, a DENY admission record with no outcome record, denied-before-dispatch
+   carrying full audit weight. Safe case: an allowlisted host produces ALLOW
+   with a paired outcome expected.
+
+2. `vector-ast09-outcome-pairing-integrity.json`: a runtime presents an
+   outcome record whose identifier matches no admission record, a stitched
+   pair. Expected: pairing fails. Safe case: a matching pair verifies.
+
+## Out of scope
+
+Cross-execution causal linkage (connecting one skill's outcome to the next
+skill's admission) is under active discussion in #44 and is deliberately not
+addressed here, so the single-execution fixture shape and the multi-skill
+extension do not get tangled together.
+
+Signatures on admission records follow the current AST09 guidance and are
+not introduced by this proposal.
+
+## License
+
+Contributions to this repository are CC BY-SA 4.0 per its LICENSE.

--- a/proposals/ast-fixture-corpus/vector-ast09-deny-network-egress.json
+++ b/proposals/ast-fixture-corpus/vector-ast09-deny-network-egress.json
@@ -1,0 +1,70 @@
+{
+  "vectorId": "ast09-deny-network-egress",
+  "astControl": "AST09",
+  "threatScenario": "A skill attempts outbound network egress to a host outside its declared allowlist, the exfiltration path AST09 names.",
+  "request": {
+    "action_type": "network.send",
+    "scope": "host:exfil.example.net",
+    "example_extensions": {
+      "_comment": "Runtime-specific request fields are illustrative only, never normative.",
+      "sint_request": {
+        "resource_uri": "sint://net/egress",
+        "params": {
+          "host": "exfil.example.net"
+        }
+      }
+    }
+  },
+  "authorityContext": {
+    "policy_version": "governance-policy-2.1.0",
+    "delegated": false
+  },
+  "expectedEnforcementPoint": "pre-dispatch admission gate",
+  "expectedDecision": "DENY",
+  "expectedAuditArtifact": {
+    "kind": "admission_record",
+    "preimage_fields": [
+      "agent_id",
+      "action_type",
+      "scope",
+      "timestamp_ms"
+    ],
+    "record": {
+      "action_ref": "66970ab5ef877aa890ace6a2a8ae96e23336e4f4414941671e315824732d534e",
+      "agent_id": "agent:example:fixture-0001",
+      "action_type": "network.send",
+      "scope": "host:exfil.example.net",
+      "timestamp_ms": 1751600000000,
+      "policy_version": "governance-policy-2.1.0",
+      "decision": "DENY"
+    },
+    "outcome_record_expected": false,
+    "property": "Denied-before-dispatch: a DENY admission with no outcome record for its action_ref evidences the action was blocked before dispatch."
+  },
+  "safeCase": {
+    "request": {
+      "action_type": "network.send",
+      "scope": "host:api.approved.example.com"
+    },
+    "expectedDecision": "ALLOW",
+    "expectedAuditArtifact": {
+      "kind": "admission_record",
+      "preimage_fields": [
+        "agent_id",
+        "action_type",
+        "scope",
+        "timestamp_ms"
+      ],
+      "record": {
+        "action_ref": "ab09f5009459e3f9ae3caadd44f7368af26fb29ed92ea6f1dac661c9fd92e850",
+        "agent_id": "agent:example:fixture-0001",
+        "action_type": "network.send",
+        "scope": "host:api.approved.example.com",
+        "timestamp_ms": 1751600001000,
+        "policy_version": "governance-policy-2.1.0",
+        "decision": "ALLOW"
+      },
+      "outcome_record_expected": true
+    }
+  }
+}

--- a/proposals/ast-fixture-corpus/vector-ast09-outcome-pairing-integrity.json
+++ b/proposals/ast-fixture-corpus/vector-ast09-outcome-pairing-integrity.json
@@ -1,0 +1,53 @@
+{
+  "vectorId": "ast09-outcome-pairing-integrity",
+  "astControl": "AST09",
+  "threatScenario": "A runtime presents an outcome record whose action_ref matches no admission record, a stitched pair that fabricates evidence of an authorized execution.",
+  "request": {
+    "action_type": "file.read",
+    "scope": "path:/data/reports/**"
+  },
+  "authorityContext": {
+    "policy_version": "governance-policy-2.1.0",
+    "delegated": false
+  },
+  "expectedEnforcementPoint": "post-execution verification (pairing check)",
+  "expectedDecision": "FAIL_PAIRING",
+  "expectedAuditArtifact": {
+    "kind": "pairing_check",
+    "preimage_fields": [
+      "agent_id",
+      "action_type",
+      "scope",
+      "timestamp_ms"
+    ],
+    "admission_records_present": [
+      "7fb0077c205e43eaa34cf59da8167ebfbdc8fbe07d2fc68d30889ed55877a350"
+    ],
+    "presented_outcome": {
+      "action_ref": "b8d3cf18c3e0173b4f9a7812137cb2fdb9bad4e14aaf3a3e8eefa527b7fb9785",
+      "status": "completed",
+      "timestamp_ms": 1751600003500
+    },
+    "property": "An outcome record whose action_ref matches no admission record MUST fail pairing; the content-derived identifier prevents after-the-fact stitching."
+  },
+  "safeCase": {
+    "expectedDecision": "PASS_PAIRING",
+    "expectedAuditArtifact": {
+      "kind": "pairing_check",
+      "preimage_fields": [
+        "agent_id",
+        "action_type",
+        "scope",
+        "timestamp_ms"
+      ],
+      "admission_records_present": [
+        "7fb0077c205e43eaa34cf59da8167ebfbdc8fbe07d2fc68d30889ed55877a350"
+      ],
+      "presented_outcome": {
+        "action_ref": "7fb0077c205e43eaa34cf59da8167ebfbdc8fbe07d2fc68d30889ed55877a350",
+        "status": "completed",
+        "timestamp_ms": 1751600002400
+      }
+    }
+  }
+}


### PR DESCRIPTION
Scoped per the shape @kenhuangus outlined in #8: a proposal, not a conformance program.

What this adds under `proposals/ast-fixture-corpus/`:

- `proposal.md` defining the minimal vector field set: `astControl`, threat scenario, request/action envelope, authority context, expected enforcement point, expected decision, expected audit artifact, and the safe-case counterpart. Runtime-specific request fields (a SINT-style shape appears in one example) live under `request.example_extensions` and are illustrative only, never normative.
- Two illustrative AST09 vectors aligned with the execution-receipts guidance: denied-before-dispatch network egress, and outcome-pairing integrity against a stitched pair. Every content-derived identifier in both vectors recomputes under the Python `rfc8785` reference implementation.

One addition beyond the #8 outline, taken from the #45 discussion: artifacts that use content-derived identifiers declare `preimage_fields` explicitly. The five-field derivation in #45 and the four-field derivation used here are both consistent with the AST09 wording, and declared preimages keep fixtures from different implementations mutually checkable without guesswork.

Cross-execution linkage is deliberately out of scope with a pointer to #44, per the untangling note in #17.

Happy to cut anything that overreaches. Field names are freely bikesheddable.
