### PR TITLE
docs(threat-intelligence): add ATR wild-scan dataset as external research reference

### DIFF
--- a/threat-intelligence.md
+++ b/threat-intelligence.md
@@ -371,6 +371,16 @@ function updateActors(data) {
 
 ## Recent Security Research
 
+### ATR Wild Ecosystem Scan Dataset (April 2026)
+- **Scope**: 101,280 skills / MCP definitions scanned across 5 public registries (OpenClaw, ClawHub, Skills.sh, Hermes, MCP Registry)
+- **Key Finding**: 1,434 flagged files (1,507 rule matches: 1,210 critical, 282 high, 15 medium)
+- **Coordinated Activity**: 552 of the flagged files belong to 3 coordinated threat-actor accounts
+- **Confirmed Malware**: a separate manual campaign analysis confirmed 751 skills as malicious
+- **Source Material** (externally hosted, independently inspectable; no payload strings redistributed):
+  - [Findings CSV](https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/docs/research/wild-scan-findings-2026-04.csv) — registry, rule id, category, severity per flagged file
+  - [Methodology](https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/docs/research/wild-scan-findings-2026-04-methodology.md) — scan scope, engine snapshot, severity breakdown, reproduction notes
+  - [Campaign analysis](https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/docs/research/96k-scan-751-malware-article.md) — the manual confirmation layered on the flagged set
+
 ### Snyk ToxicSkills Report (March 2026)
 - **Key Finding**: 37.1% of skills contain security flaws
 - **Critical Vulnerabilities**: 13.7%
@@ -443,6 +453,7 @@ If you discover a malicious skill or security threat:
 - Platform Security Teams (ClawHub, Anthropic, etc.)
 - Community Reports
 - Automated Scanning Systems
+- Agent Threat Rules (ATR) wild-scan dataset (open data, MIT)
 
 ---
 


### PR DESCRIPTION
Adds a citation-oriented external reference entry under Recent Security Research in threat-intelligence.md, per maintainer guidance in #22.

Scope, kept deliberately small:
- one entry pointing to the externally hosted findings CSV, methodology, and campaign analysis
- summarizes only what those public artifacts directly support (101,280 items scanned across 5 registries; 1,434 flagged files with 1,507 rule matches; 552 flagged files tied to 3 coordinated threat-actor accounts; 751 skills confirmed malicious by the separate manual campaign analysis)
- no downstream adoption claims
- one line added to Intelligence Sources

The ATR -> AST crosswalk suggested in #22 is intentionally not in this PR; it will come as a separate PR with the generation method and rule-metadata join keys, so the evidence mapping can be reviewed independently.

Closes the reference-corpus half of #22.
