### PR TITLE
docs(threat-intelligence): add ATR -> AST detection crosswalk reference

### DIFF
--- a/threat-intelligence.md
+++ b/threat-intelligence.md
@@ -444,6 +444,21 @@ If you discover a malicious skill or security threat:
 - Community Reports
 - Automated Scanning Systems
 
+## External Detection Crosswalks
+
+Externally maintained mappings from detection rulesets to the AST controls, for
+teams that want executable detections aligned to this Top 10:
+
+- **Agent Threat Rules (ATR) -> AST crosswalk** — maps ATR detection rules to
+  AST01-AST10.
+  [Crosswalk document](https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/docs/crosswalks/atr-ast-crosswalk.md).
+  Generation method (documented at the link): a curated thematic mapping over
+  the ATR `tags.category` enum as the primary join key, with
+  `references.owasp_agentic` as secondary evidence; it is not an id-equality
+  join, and it reports AST07/AST08/AST10 as out of scope for runtime detection
+  rather than claiming coverage. Regenerated from rule metadata and CI-checked
+  so the mapping does not drift.
+
 ---
 
 *Threat intelligence is updated daily. Last update: March 22, 2026*


### PR DESCRIPTION
Per your guidance in #22 — the ATR -> AST crosswalk as a **separate** reference so it can be reviewed independently from the reference-corpus citation (that one is in a separate PR).

Adds one "External Detection Crosswalks" entry pointing to the externally hosted [ATR -> AST crosswalk](https://github.com/Agent-Threat-Rule/agent-threat-rules/blob/main/docs/crosswalks/atr-ast-crosswalk.md).

Generation method + join keys (as requested), summarized in the entry and documented in full at the link:
- **Primary join key:** ATR `tags.category` (closed 9-value enum), via a curated `category -> AST` table with a per-entry rationale — applied mechanically, regenerated from metadata, CI-checked against drift.
- **Secondary evidence:** `references.owasp_agentic` (ASI), surfaced as context, not as the mapping basis.
- Not an id-equality join (ATR has no native AST id), and explicitly labelled as such.
- Honest non-coverage: AST07 / AST08 / AST10 report 0 rules (lifecycle/process controls a detection rule doesn't fire on), not padded.