### PR TITLE
docs(scanner-integration): clarify digest join boundary

### DIFF
--- a/skill-scanner-integration.md
+++ b/skill-scanner-integration.md
@@ -401,6 +401,15 @@ The SARIF `artifacts[]` + `hashes` mechanism makes this deterministic. A scanner
 
 A consumer merges N reports by grouping `artifacts[]` across runs on `hashes["sha-256"]`, attaching each run's results via `artifactLocation.index`, and partitioning by `layer` — no content re-hashing and no coordination between the tools.
 
+The digest join is an artifact identity mechanism, not a risk-score mechanism.
+Consumers SHOULD preserve scanner-layer attribution when merging reports by
+artifact digest. A digest match establishes that findings concern the same
+artifact bytes; it does not by itself define an aggregate risk score, prove
+absence of findings from scanner layers that did not run or were truncated, or
+imply that the artifact is safe. If a registry or dashboard wants a single
+policy verdict, that verdict should be produced by an explicit consumer policy
+over the layer-preserved findings rather than by the merge step itself.
+
 ```json
 {
   "runs": [


### PR DESCRIPTION
## What

Clarifies the multi-scanner interoperability section with one boundary rule: joining SARIF reports by `artifacts[].hashes["sha-256"]` establishes shared artifact identity, not a single aggregate risk verdict.

## Why

The existing section correctly defines the portable SARIF join shape:

- artifact SHA-256 as the cross-tool join key;
- `artifactLocation.index` to bind findings to bytes;
- `result.properties.layer` to preserve scanner class;
- tool name/version for provenance.

The only missing boundary is how a consumer should read the merged view. A missing scanner layer, truncated SARIF, or a scanner that did not run should not read as clean evidence. This small paragraph keeps the merge layer tool-neutral and layer-preserving: a registry or dashboard can still produce a single policy verdict, but that verdict belongs to an explicit consumer policy over the preserved findings, not to the digest join itself.

## Scope

Docs-only. No new scanner, no fixture schema, no conformance program, and no change to the AST09 fixture/receipt threads.

## Verification

- `bash validate.sh`
