### PR TITLE
docs(ast09): tighten the claim boundary on the deny example vector

### DIFF
--- a/examples/ast09-execution-receipts/README.md
+++ b/examples/ast09-execution-receipts/README.md
@@ -44,7 +44,7 @@ subject to the limits stated above.
 ```
 python3 check.py deny-admission-receipt.json           # ALL CHECKS PASS, exit 0
 python3 check.py deny-admission-receipt.tampered.json  # FAIL (attempt_id), exit 1
-python3 check.py --selftest                            # asserts valid exit 0, tampered exit 1
+python3 check.py --selftest                            # six cases: exit, stderr, named output
 ```
 
 ## Field derivation
@@ -52,9 +52,10 @@ python3 check.py --selftest                            # asserts valid exit 0, t
 `attempt_id` is the lowercase sha256 hex over the RFC 8785 (JCS) canonical bytes of
 `{agent_id, action_type, scope, policy_version, timestamp_ms}`, which is one derivation consistent
 with the guidance's "content-derived identifier" wording and not a normative requirement (any
-deterministic content-derived scheme that lets a verifier recompute the identifier and detect a
-dropped or altered record satisfies the property). The `agent_id` is synthetic and `timestamp_ms`
-is a fixed deterministic value, not a wall-clock read.
+deterministic content-derived scheme that lets a verifier recompute the identifier satisfies the
+derivation property; a mismatch shows inconsistency between the stored identifier and the fields
+it commits, while detecting that a record was omitted belongs to the record set). The `agent_id`
+is synthetic and `timestamp_ms` is a fixed deterministic value, not a wall-clock read.
 
 This five-field derivation commits agent_id, action_type, scope, policy_version and timestamp_ms,
 and nothing else: it does not commit `decision` and it does not commit itself. It cannot serve as a pairing key, because a party

--- a/examples/ast09-execution-receipts/README.md
+++ b/examples/ast09-execution-receipts/README.md
@@ -31,8 +31,10 @@ alone.
 The AST09 Key Property that denied-before-dispatch carries equal audit weight: a DENY admission
 record is an auditable artifact in its own right, whether or not execution followed. Absence of an
 outcome receipt for its `attempt_id` is consistent with the action having been blocked before
-dispatch; it does not establish it, which would require an authenticated commitment that the set
-of outcome receipts examined was complete over a defined window. The checker validates the record from the bytes alone, with no call to any runtime:
+dispatch; it does not establish it. That inference needs two conditions: an authenticated
+commitment that the set of outcome receipts examined is complete for the relevant window, and an
+execution profile under which every dispatch is coupled to a receipt. Without the second, a
+complete set can be empty while an action executed by a path that emits nothing. The checker validates the record from the bytes alone, with no call to any runtime:
 the seven required fields are present, decision is DENY, and `attempt_id` recomputes from the
 content preimage, which is the only integrity check available in a signature-free admission record,
 subject to the limits stated above.

--- a/examples/ast09-execution-receipts/README.md
+++ b/examples/ast09-execution-receipts/README.md
@@ -29,8 +29,10 @@ alone.
 ## What it demonstrates
 
 The AST09 Key Property that denied-before-dispatch carries equal audit weight: a DENY admission
-record with no outcome receipt for its `attempt_id` evidences the action was blocked before
-dispatch. The checker validates the record from the bytes alone, with no call to any runtime:
+record is an auditable artifact in its own right, whether or not execution followed. Absence of an
+outcome receipt for its `attempt_id` is consistent with the action having been blocked before
+dispatch; it does not establish it, which would require an authenticated commitment that the set
+of outcome receipts examined was complete over a defined window. The checker validates the record from the bytes alone, with no call to any runtime:
 the seven required fields are present, decision is DENY, and `attempt_id` recomputes from the
 content preimage, which is the only integrity check available in a signature-free admission record,
 subject to the limits stated above.
@@ -52,8 +54,8 @@ deterministic content-derived scheme that lets a verifier recompute the identifi
 dropped or altered record satisfies the property). The `agent_id` is synthetic and `timestamp_ms`
 is a fixed deterministic value, not a wall-clock read.
 
-This five-field derivation is a seal: it commits `policy_version`, which nothing else in a
-signature-free Admission receipt protects. It cannot serve as a pairing key, because a party
+This five-field derivation commits agent_id, action_type, scope, policy_version and timestamp_ms,
+and nothing else: it does not commit `decision` and it does not commit itself. It cannot serve as a pairing key, because a party
 recomputing the identifier from the executed request would need `policy_version`, which the
 executing party need not know. The four-field derivation in `proposals/ast-fixture-corpus` is a
 pairing key for exactly that reason. Both fit the guidance's "content-derived identifier" wording.

--- a/examples/ast09-execution-receipts/README.md
+++ b/examples/ast09-execution-receipts/README.md
@@ -8,8 +8,14 @@ record, offline-verifiable from its own bytes, with no outcome receipt and no ru
 
 The AST09 Admission receipt is the seven documented fields and carries no signature (a signature
 is documented only on the Outcome receipt). This vector therefore contains no signature and no
-keypair. Tamper detection is the content-derived identifier: `attempt_id` is a hash over the
-admission content, so altering any preimage field makes the stored `attempt_id` fail to recompute.
+keypair.
+
+What the content-derived `attempt_id` gives, and what it does not: altering any preimage field
+makes the stored `attempt_id` fail to recompute, so an alteration is detectable by a verifier that
+holds the identifier from a source other than the record itself. A party who can rewrite the record
+can also rewrite the identifier, so this is not tamper evidence against the record's own writer.
+With no signature on the Admission receipt, no stronger property is available from these bytes
+alone.
 
 ## Files
 
@@ -26,7 +32,8 @@ The AST09 Key Property that denied-before-dispatch carries equal audit weight: a
 record with no outcome receipt for its `attempt_id` evidences the action was blocked before
 dispatch. The checker validates the record from the bytes alone, with no call to any runtime:
 the seven required fields are present, decision is DENY, and `attempt_id` recomputes from the
-content preimage, which is the sole tamper-detection mechanism in a signature-free admission record.
+content preimage, which is the only integrity check available in a signature-free admission record,
+subject to the limits stated above.
 
 ## Run
 
@@ -45,11 +52,19 @@ deterministic content-derived scheme that lets a verifier recompute the identifi
 dropped or altered record satisfies the property). The `agent_id` is synthetic and `timestamp_ms`
 is a fixed deterministic value, not a wall-clock read.
 
+This five-field derivation is a seal: it commits `policy_version`, which nothing else in a
+signature-free Admission receipt protects. It cannot serve as a pairing key, because a party
+recomputing the identifier from the executed request would need `policy_version`, which the
+executing party need not know. The four-field derivation in `proposals/ast-fixture-corpus` is a
+pairing key for exactly that reason. Both fit the guidance's "content-derived identifier" wording.
+They are not interchangeable.
+
 ## Claim boundary
 
-The checker proves record integrity and decision binding, meaning the record is intact and the
-DENY decision is carried in a record whose identifier is bound to the requested scope and policy
-version; it does not prove that the policy decision itself was correct, which is a separate question.
+The checker demonstrates that the record is internally consistent and that the DENY decision is
+carried in a record whose identifier commits to the requested scope and policy version. It does not
+show that the record is tamper evident against its own writer, that the action was not executed by
+some path that produced no receipt, or that the policy decision itself was correct.
 
 ## License
 

--- a/examples/ast09-execution-receipts/README.md
+++ b/examples/ast09-execution-receipts/README.md
@@ -44,8 +44,12 @@ subject to the limits stated above.
 ```
 python3 check.py deny-admission-receipt.json           # ALL CHECKS PASS, exit 0
 python3 check.py deny-admission-receipt.tampered.json  # FAIL (attempt_id), exit 1
-python3 check.py --selftest                            # six cases: exit, stderr, named output
+python3 check.py --selftest                            # ten cases: exit, stderr, named output
 ```
+
+The exit code is the interface. Input-derived text is JSON-escaped so it cannot create
+additional physical output lines; consumers MUST NOT infer success from substring matches
+in stdout.
 
 ## Field derivation
 

--- a/examples/ast09-execution-receipts/check.py
+++ b/examples/ast09-execution-receipts/check.py
@@ -37,7 +37,7 @@ dependency and no INCOMPLETE path.
 Usage:
   python3 check.py deny-admission-receipt.json
   python3 check.py deny-admission-receipt.tampered.json
-  python3 check.py --selftest     # run both bundled receipts and assert the exit contract
+  python3 check.py --selftest     # run six cases and assert exit code plus named output
 
 Exit codes:
   0  all checks pass
@@ -48,10 +48,12 @@ Exit codes:
 """
 
 import hashlib
+import io
 import json
 import os
 import subprocess
 import sys
+import tempfile
 
 REQUIRED_FIELDS = [
     "attempt_id", "agent_id", "action_type", "scope",
@@ -72,12 +74,43 @@ def sha256_hex(s):
     return hashlib.sha256(s.encode("utf-8")).hexdigest()
 
 
+def _reject_duplicate_names(pairs):
+    """RFC 8785 forbids duplicate property names, and json.load would silently keep the
+    last, so two parsers could disagree about what this record says."""
+    seen = set()
+    for k, _ in pairs:
+        if k in seen:
+            raise ValueError("duplicate property name %s: RFC 8785 forbids duplicates"
+                             % json.dumps(k))
+        seen.add(k)
+    return dict(pairs)
+
+
+def _reject_lone_surrogates(value, where="the record"):
+    """No unpaired surrogate has a UTF-8 encoding. Reject the whole document up front,
+    property names included, so no later step can fail on an unprintable value."""
+    if isinstance(value, str):
+        if any(0xD800 <= ord(c) <= 0xDFFF for c in value):
+            raise ValueError("unpaired surrogate in %s: no UTF-8 encoding exists" % where)
+    elif isinstance(value, dict):
+        for k, v in value.items():
+            _reject_lone_surrogates(k, "a property name")
+            _reject_lone_surrogates(v, "property %s" % json.dumps(k))
+    elif isinstance(value, list):
+        for v in value:
+            _reject_lone_surrogates(v, where)
+
+
 def check_receipt(path):
     """Run every check on one receipt and return an int exit code:
     0 all pass, 1 a check failed (reasons named)."""
     try:
         with open(path, encoding="utf-8") as f:
-            rec = json.load(f)
+            rec = json.load(f, object_pairs_hook=_reject_duplicate_names)
+        if not isinstance(rec, dict):
+            print("FAIL  top-level JSON value must be an object, got %s" % type(rec).__name__)
+            return 1
+        _reject_lone_surrogates(rec)
     except Exception as e:
         print("FAIL  could not read or parse %s: %s" % (path, e))
         return 1
@@ -122,7 +155,9 @@ def check_receipt(path):
         "" if not domain_errors else " (%s)" % "; ".join(domain_errors)))
 
     # 4. attempt_id recomputes from the five-field preimage. Reach is bounded; see module docstring.
-    if all(k in rec for k in ATTEMPT_ID_PREIMAGE_FIELDS):
+    if domain_errors:
+        print("SKIP attempt_id recompute (preimage outside the supported domain)")
+    elif all(k in rec for k in ATTEMPT_ID_PREIMAGE_FIELDS):
         preimage = {k: rec[k] for k in ATTEMPT_ID_PREIMAGE_FIELDS}
         expected = sha256_hex(jcs(preimage))
         ok_attempt = rec.get("attempt_id") == expected
@@ -166,28 +201,94 @@ def check_receipt(path):
     return rc
 
 
+def _run_case(label, argpath, expect_exit, expect_out=(), forbid_out=()):
+    res = subprocess.run([sys.executable, os.path.abspath(__file__), argpath],
+                         capture_output=True, text=True)
+    problems = []
+    if res.returncode != expect_exit:
+        problems.append("expected exit %d, got %d" % (expect_exit, res.returncode))
+    if res.stderr.strip():
+        problems.append("stderr is not empty; a crash is not a named failure")
+    if "Traceback" in res.stderr:
+        problems.append("traceback present")
+    for s in expect_out:
+        if s not in res.stdout:
+            problems.append("missing from output: %s" % json.dumps(s))
+    for s in forbid_out:
+        if s in res.stdout:
+            problems.append("must not appear in output: %s" % json.dumps(s))
+    print("  %s  %-34s %s" % ("PASS" if not problems else "FAIL", label,
+                              "" if not problems else "; ".join(problems)))
+    return not problems
+
+
 def selftest():
-    """Run both bundled receipts as subprocesses and assert the exit-code contract:
-    exit 0 on the valid receipt, exit 1 on the tampered receipt. Fail loudly (nonzero)
-    if either is wrong. Uses real subprocess exit codes, so it tests exactly what a
-    shell sees."""
+    """Run six cases as subprocesses and assert exit code, empty stderr, and named output.
+
+    Exit code alone cannot separate a named rejection from an uncaught exception, because
+    both leave the process with status 1. Each case therefore also pins a string the output
+    must contain, and the tampered case pins one it must not.
+
+    Two bundled receipts cover the pass and mismatch paths. Four hostile records are built
+    in a temporary directory and removed afterwards, so the cases added here contribute no
+    new files to the repository."""
     here = os.path.dirname(os.path.abspath(__file__))
-    me = os.path.abspath(__file__)
-    cases = [("deny-admission-receipt.json", 0), ("deny-admission-receipt.tampered.json", 1)]
-    print("== self-test: exit-code contract ==")
-    all_ok = True
-    for fname, expect in cases:
-        res = subprocess.run([sys.executable, me, os.path.join(here, fname)],
-                             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        got = res.returncode
-        ok = got == expect
-        all_ok = all_ok and ok
-        print("  %s  %-38s expected exit %d, got exit %d" % ("PASS" if ok else "FAIL", fname, expect, got))
-    if all_ok:
+    print("== self-test: exit code, empty stderr, and named output ==")
+    results = []
+
+    results.append(_run_case(
+        "valid fixture", os.path.join(here, "deny-admission-receipt.json"), 0,
+        expect_out=("What this checker established",)))
+    results.append(_run_case(
+        "tampered fixture", os.path.join(here, "deny-admission-receipt.tampered.json"), 1,
+        expect_out=("No property is asserted",),
+        forbid_out=("What this checker established",)))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # Written as raw text: a duplicate name cannot survive a dict, so it has to
+        # reach the parser as bytes.
+        dup = os.path.join(tmp, "duplicate-name.json")
+        with io.open(dup, "w", encoding="utf-8") as f:
+            f.write('{"attempt_id":"x","agent_id":"a","action_type":"t",'
+                    '"scope":"s","scope":"s","policy_version":"p",'
+                    '"decision":"DENY","timestamp_ms":1}')
+        results.append(_run_case(
+            "duplicate property name", dup, 1,
+            expect_out=("duplicate property name",)))
+
+        # A lone surrogate is expressible in JSON source but has no UTF-8 encoding.
+        sur = os.path.join(tmp, "lone-surrogate.json")
+        with io.open(sur, "w", encoding="utf-8") as f:
+            f.write('{"attempt_id":"x","agent_id":"\\ud800","action_type":"t",'
+                    '"scope":"s","policy_version":"p","decision":"DENY","timestamp_ms":1}')
+        results.append(_run_case(
+            "unpaired surrogate", sur, 1,
+            expect_out=("unpaired surrogate",)))
+
+        # A float is perfectly hashable, so this exercises the domain gate itself
+        # rather than riding a crash path.
+        flt = os.path.join(tmp, "float-timestamp.json")
+        with io.open(flt, "w", encoding="utf-8") as f:
+            f.write('{"attempt_id":"x","agent_id":"a","action_type":"t","scope":"s",'
+                    '"policy_version":"p","decision":"DENY","timestamp_ms":1.5}')
+        results.append(_run_case(
+            "float timestamp_ms", flt, 1,
+            expect_out=("must be an integer", "SKIP attempt_id recompute")))
+
+        arr = os.path.join(tmp, "top-level-array.json")
+        with io.open(arr, "w", encoding="utf-8") as f:
+            f.write ('[]')
+        results.append(_run_case(
+            "top-level array", arr, 1,
+            expect_out=("top-level JSON value must be an object",)))
+
+    if all(results):
         print("SELF-TEST PASS")
         return 0
-    print("SELF-TEST FAILED: the exit-code contract is violated "
-          "(the valid receipt must exit 0 and the tampered receipt must exit 1).")
+    print("SELF-TEST FAILED: %d of %d cases did not hold. Each case pins an exit code, an "
+          "empty stderr, and named output; a case that fails only on output means the "
+          "checker still exits correctly while no longer saying why."
+          % (len([r for r in results if not r]), len(results)))
     return 1
 
 

--- a/examples/ast09-execution-receipts/check.py
+++ b/examples/ast09-execution-receipts/check.py
@@ -2,19 +2,32 @@
 """Offline checker for the AST09 denied-before-dispatch admission-receipt vector.
 
 The AST09 Admission receipt is seven fields and carries no signature (a signature is
-documented only on the Outcome receipt). Tamper detection here is the content-derived
-identifier: the attempt_id is a hash over the admission content, so altering any field
-in the preimage makes the stored attempt_id fail to recompute.
+documented only on the Outcome receipt). The content-derived identifier is what makes an
+alteration detectable, and its reach is bounded: attempt_id is a hash over FIVE of the seven
+fields (agent_id, action_type, scope, policy_version, timestamp_ms). It does not commit
+`decision` and it does not commit itself. Rewriting DENY to ALLOW leaves an attempt_id that
+still recomputes, so this checker asserts the decision directly rather than relying on the
+identifier to carry it.
 
 Verifies, from the record bytes alone, with no runtime call and no network:
 
   1. the seven required fields are present
-  2. decision is DENY
-  3. attempt_id recomputes from the content preimage (RFC 8785 / JCS, then sha256)
+  2. decision is DENY, asserted directly because the identifier does not cover it
+  3. every preimage value is inside this canonicalizer's supported domain
+  4. attempt_id recomputes from the five-field preimage (RFC 8785 / JCS, then sha256)
 
-Denied-before-dispatch property (AST09 Key Properties): a DENY admission record with
-no outcome receipt for a given attempt_id evidences the action was blocked before
-dispatch.
+Canonicalization domain, stated at module level because copying jcs() out of this file
+without it is a real hazard: the function below is correct for THIS vector's value space,
+which is four ASCII-keyed strings and one integer. It is not a general RFC 8785
+implementation. It does not handle floats, non-ASCII property names requiring UTF-16
+code-unit ordering, or integers outside the I-JSON safe range. Step 3 enforces that
+boundary rather than assuming it.
+
+What absence does and does not show: a DENY admission record with no outcome receipt for its
+attempt_id is consistent with the action having been blocked before dispatch. It does not
+establish it. That would require an authenticated commitment that the set of outcome receipts
+examined was complete over a defined window. This checker reads one record and makes no
+completeness claim.
 
 Standard library only. There is no signature to verify, so there is no cryptography
 dependency and no INCOMPLETE path.
@@ -91,7 +104,25 @@ def check_receipt(path):
         failures.append("decision is %r, expected DENY" % decision)
     print("%s decision is DENY (got %r)" % ("OK  " if ok_decision else "FAIL", decision))
 
-    # 3. attempt_id recomputes from the content preimage (sole tamper-detection mechanism)
+    # 3. preimage values inside this canonicalizer's supported domain (see module docstring)
+    domain_errors = []
+    for k in ATTEMPT_ID_PREIMAGE_FIELDS:
+        if k not in rec:
+            continue
+        v = rec[k]
+        if k == "timestamp_ms":
+            if isinstance(v, bool) or not isinstance(v, int):
+                domain_errors.append("%s must be an integer" % k)
+            elif abs(v) > 2 ** 53 - 1:
+                domain_errors.append("%s is outside the I-JSON safe integer range" % k)
+        elif not isinstance(v, str):
+            domain_errors.append("%s must be a string (got %s)" % (k, type(v).__name__))
+    failures.extend(domain_errors)
+    print("%s preimage values inside the supported canonicalization domain%s" % (
+        "OK  " if not domain_errors else "FAIL",
+        "" if not domain_errors else " (%s)" % "; ".join(domain_errors)))
+
+    # 4. attempt_id recomputes from the five-field preimage. Reach is bounded; see module docstring.
     if all(k in rec for k in ATTEMPT_ID_PREIMAGE_FIELDS):
         preimage = {k: rec[k] for k in ATTEMPT_ID_PREIMAGE_FIELDS}
         expected = sha256_hex(jcs(preimage))
@@ -106,9 +137,11 @@ def check_receipt(path):
 
     # Denied-before-dispatch property, printed for both receipts.
     print()
-    print("Denied-before-dispatch property (AST09): a DENY admission record with no")
-    print("outcome receipt for a given attempt_id evidences the action was blocked")
-    print("before dispatch.")
+    print("What this record shows: a DENY admission decision, internally consistent.")
+    print("Absence of an outcome receipt for this attempt_id is consistent with the")
+    print("action having been blocked before dispatch. It does not establish it: that")
+    print("needs an authenticated commitment that the outcome-receipt set examined was")
+    print("complete over a defined window.")
     print("attempt_id: %s" % rec.get("attempt_id"))
 
     # Honest, single exit code. Any named failure is exit 1; a full pass is exit 0.

--- a/examples/ast09-execution-receipts/check.py
+++ b/examples/ast09-execution-receipts/check.py
@@ -20,8 +20,10 @@ Canonicalization domain, stated at module level because copying jcs() out of thi
 without it is a real hazard: the function below is correct for THIS vector's value space,
 which is four ASCII-keyed strings and one integer. It is not a general RFC 8785
 implementation. It does not handle floats, non-ASCII property names requiring UTF-16
-code-unit ordering, or integers outside the I-JSON safe range. Step 3 enforces that
-boundary rather than assuming it.
+code-unit ordering, or integers outside the I-JSON safe range.
+The loader and the checks enforce that boundary rather than assuming it: duplicate names,
+unpaired surrogates, and non-object records are rejected at load time, unexpected property
+names fail check 1, and out-of-domain preimage values fail check 3 and skip the recompute.
 
 What absence does and does not show: a DENY admission record with no outcome receipt for its
 attempt_id is consistent with the action having been blocked before dispatch. It does not
@@ -37,7 +39,7 @@ dependency and no INCOMPLETE path.
 Usage:
   python3 check.py deny-admission-receipt.json
   python3 check.py deny-admission-receipt.tampered.json
-  python3 check.py --selftest     # run six cases and assert exit code plus named output
+  python3 check.py --selftest     # run ten cases and assert exit code plus named output
 
 Exit codes:
   0  all checks pass
@@ -45,6 +47,10 @@ Exit codes:
      attempt_id that does not recompute
   2  usage error (bad arguments). There is no cryptography INCOMPLETE path in this
      signature-free vector.
+
+The exit code is the interface. Input-derived text is JSON-escaped so it cannot create
+additional physical output lines; consumers MUST NOT infer success from substring matches
+in stdout.
 """
 
 import hashlib
@@ -112,7 +118,8 @@ def check_receipt(path):
             return 1
         _reject_lone_surrogates(rec)
     except Exception as e:
-        print("FAIL  could not read or parse %s: %s" % (path, e))
+        print("FAIL  could not read or parse %s: %s"
+              % (json.dumps(path), json.dumps(str(e))))
         return 1
 
     failures = []
@@ -123,18 +130,20 @@ def check_receipt(path):
     if missing:
         failures.append("missing required field(s): %s" % ", ".join(missing))
     if extra:
-        failures.append("unexpected field(s) for an admission receipt: %s" % ", ".join(extra))
+        failures.append("unexpected field(s) for an admission receipt: %s"
+                        % ", ".join(json.dumps(k) for k in extra))
     print("%s seven required fields present%s%s" % (
         "OK  " if not missing and not extra else "FAIL",
         "" if not missing else " (missing: %s)" % ", ".join(missing),
-        "" if not extra else " (unexpected: %s)" % ", ".join(extra)))
+        "" if not extra else " (unexpected: %s)" % ", ".join(json.dumps(k) for k in extra)))
 
     # 2. decision is DENY
     decision = rec.get("decision")
     ok_decision = decision == "DENY"
     if not ok_decision:
-        failures.append("decision is %r, expected DENY" % decision)
-    print("%s decision is DENY (got %r)" % ("OK  " if ok_decision else "FAIL", decision))
+        failures.append("decision is %s, expected DENY" % json.dumps(decision))
+    print("%s decision is DENY (got %s)" % ("OK  " if ok_decision else "FAIL",
+                                            json.dumps(decision)))
 
     # 3. preimage values inside this canonicalizer's supported domain (see module docstring)
     domain_errors = []
@@ -163,7 +172,7 @@ def check_receipt(path):
         ok_attempt = rec.get("attempt_id") == expected
         if not ok_attempt:
             failures.append("attempt_id does not recompute (stored %s..., recomputed %s...)"
-                            % (str(rec.get("attempt_id"))[:16], expected[:16]))
+                            % (json.dumps(str(rec.get("attempt_id"))[:16]), expected[:16]))
         print("%s attempt_id recomputes from content preimage" % ("OK  " if ok_attempt else "FAIL"))
     else:
         failures.append("attempt_id cannot be recomputed (preimage fields missing)")
@@ -185,7 +194,7 @@ def check_receipt(path):
         print("action ran by a path that emits nothing.")
     else:
         print("No property is asserted for a record whose checks did not pass.")
-    print("attempt_id: %s" % rec.get("attempt_id"))
+    print("attempt_id: %s" % json.dumps(rec.get("attempt_id")))
 
     # Honest, single exit code. Any named failure is exit 1; a full pass is exit 0.
     # There is no signature and therefore no INCOMPLETE path. Never exit 0 with any
@@ -201,9 +210,11 @@ def check_receipt(path):
     return rc
 
 
-def _run_case(label, argpath, expect_exit, expect_out=(), forbid_out=()):
+def _run_case(label, argpath, expect_exit, expect_out=(), forbid_out=(),
+              expect_lines=(), forbid_lines=()):
+    child_env = dict(os.environ, PYTHONIOENCODING="ascii")
     res = subprocess.run([sys.executable, os.path.abspath(__file__), argpath],
-                         capture_output=True, text=True)
+                         capture_output=True, text=True, env=child_env)
     problems = []
     if res.returncode != expect_exit:
         problems.append("expected exit %d, got %d" % (expect_exit, res.returncode))
@@ -217,21 +228,29 @@ def _run_case(label, argpath, expect_exit, expect_out=(), forbid_out=()):
     for s in forbid_out:
         if s in res.stdout:
             problems.append("must not appear in output: %s" % json.dumps(s))
+    stripped = [l.strip() for l in res.stdout.splitlines()]
+    for s in expect_lines:
+        if s not in stripped:
+            problems.append("expected line missing: %s" % json.dumps(s))
+    for s in forbid_lines:
+        if s in stripped:
+            problems.append("forbidden line present: %s" % json.dumps(s))
     print("  %s  %-34s %s" % ("PASS" if not problems else "FAIL", label,
                               "" if not problems else "; ".join(problems)))
     return not problems
 
 
 def selftest():
-    """Run six cases as subprocesses and assert exit code, empty stderr, and named output.
+    """Run ten cases as subprocesses and assert exit code, empty stderr, and named output.
 
     Exit code alone cannot separate a named rejection from an uncaught exception, because
     both leave the process with status 1. Each case therefore also pins a string the output
     must contain, and the tampered case pins one it must not.
 
-    Two bundled receipts cover the pass and mismatch paths. Four hostile records are built
-    in a temporary directory and removed afterwards, so the cases added here contribute no
-    new files to the repository."""
+    Two bundled receipts cover the pass and mismatch paths. Seven hostile input files
+    are written to a temporary directory and removed with it. One additional case
+    passes a nonexistent path inside that directory. The cases here therefore
+    contribute no new files to the repository."""
     here = os.path.dirname(os.path.abspath(__file__))
     print("== self-test: exit code, empty stderr, and named output ==")
     results = []
@@ -281,6 +300,56 @@ def selftest():
         results.append(_run_case(
             "top-level array", arr, 1,
             expect_out=("top-level JSON value must be an object",)))
+
+        # Cases 7 to 10 pin the output boundary and the two checks that had no
+        # coverage. The toy preimage's attempt_id is recomputed with this module's
+        # own jcs and sha256_hex, so cases 8 and 9 have exactly one failing check.
+        # That the same aid holds across a hostile decision also shows, inside the
+        # self-test, that decision is not committed by the identifier.
+        pre = {"agent_id": "a", "action_type": "t", "scope": "s",
+               "policy_version": "p", "timestamp_ms": 1}
+        aid = sha256_hex(jcs(pre))
+        aid_canary = "\nFORGED-AID\n\u00e9\nALL CHECKS PASS\nWhat this checker established: forged"
+        dec_hostile = "ALLOW\u00e9\nFORGED-DECISION\n"
+        name_hostile = "signatur\u00e9\nFORGED-FIELD\n"
+
+        forged = os.path.join(tmp, "forged-attempt-id.json")
+        rec = dict(pre, attempt_id=aid_canary, decision="DENY")
+        with io.open(forged, "w", encoding="utf-8") as f:
+            f.write(json.dumps(rec))
+        results.append(_run_case(
+            "forged attempt_id", forged, 1,
+            expect_out=("attempt_id does not recompute", "No property is asserted"),
+            expect_lines=('attempt_id: "\\nFORGED-AID\\n\\u00e9\\nALL CHECKS PASS\\nWhat this checker established: forged"',),
+            forbid_lines=("FORGED-AID", "ALL CHECKS PASS",
+                          "What this checker established: forged")))
+
+        hostile_dec = os.path.join(tmp, "hostile-decision.json")
+        rec = dict(pre, attempt_id=aid, decision=dec_hostile)
+        with io.open(hostile_dec, "w", encoding="utf-8") as f:
+            f.write(json.dumps(rec))
+        results.append(_run_case(
+            "hostile decision", hostile_dec, 1,
+            expect_lines=('FAIL decision is DENY (got "ALLOW\\u00e9\\nFORGED-DECISION\\n")',
+                          '- decision is "ALLOW\\u00e9\\nFORGED-DECISION\\n", expected DENY'),
+            forbid_lines=("FORGED-DECISION", "ALL CHECKS PASS")))
+
+        hostile_name = os.path.join(tmp, "hostile-field-name.json")
+        rec = dict(pre, attempt_id=aid, decision="DENY")
+        rec[name_hostile] = "x"
+        with io.open(hostile_name, "w", encoding="utf-8") as f:
+            f.write(json.dumps(rec))
+        results.append(_run_case(
+            "hostile field name", hostile_name, 1,
+            expect_lines=('FAIL seven required fields present (unexpected: "signatur\\u00e9\\nFORGED-FIELD\\n")',
+                          '- unexpected field(s) for an admission receipt: "signatur\\u00e9\\nFORGED-FIELD\\n"'),
+            forbid_lines=("FORGED-FIELD", "ALL CHECKS PASS")))
+
+        results.append(_run_case(
+            "hostile path",
+            os.path.join(tmp, "missing\nFORGED-PATH\nALL CHECKS PASS\n"), 1,
+            expect_out=("could not read or parse",),
+            forbid_lines=("FORGED-PATH", "ALL CHECKS PASS")))
 
     if all(results):
         print("SELF-TEST PASS")

--- a/examples/ast09-execution-receipts/check.py
+++ b/examples/ast09-execution-receipts/check.py
@@ -25,9 +25,11 @@ boundary rather than assuming it.
 
 What absence does and does not show: a DENY admission record with no outcome receipt for its
 attempt_id is consistent with the action having been blocked before dispatch. It does not
-establish it. That would require an authenticated commitment that the set of outcome receipts
-examined was complete over a defined window. This checker reads one record and makes no
-completeness claim.
+establish it. That inference needs two conditions this checker does not have: an authenticated
+commitment that the set of outcome receipts examined is complete for the relevant window, and an
+execution profile under which every dispatch is coupled to a receipt. Without the second, a
+complete set can be empty while an action executed by a path that emits nothing. This checker
+reads one record and makes no completeness claim.
 
 Standard library only. There is no signature to verify, so there is no cryptography
 dependency and no INCOMPLETE path.
@@ -93,9 +95,6 @@ def check_receipt(path):
         "OK  " if not missing and not extra else "FAIL",
         "" if not missing else " (missing: %s)" % ", ".join(missing),
         "" if not extra else " (unexpected: %s)" % ", ".join(extra)))
-    if "timestamp_ms" in rec and not isinstance(rec["timestamp_ms"], int):
-        failures.append("timestamp_ms is not an integer")
-        print("FAIL timestamp_ms is an integer (got %r)" % type(rec["timestamp_ms"]).__name__)
 
     # 2. decision is DENY
     decision = rec.get("decision")
@@ -135,13 +134,22 @@ def check_receipt(path):
         failures.append("attempt_id cannot be recomputed (preimage fields missing)")
         print("FAIL attempt_id recompute (preimage fields missing)")
 
-    # Denied-before-dispatch property, printed for both receipts.
+    # Denied-before-dispatch property. The assertion is made only when every check
+    # passed; attempt_id prints on both paths because it is a diagnostic, not a claim.
     print()
-    print("What this record shows: a DENY admission decision, internally consistent.")
-    print("Absence of an outcome receipt for this attempt_id is consistent with the")
-    print("action having been blocked before dispatch. It does not establish it: that")
-    print("needs an authenticated commitment that the outcome-receipt set examined was")
-    print("complete over a defined window.")
+    if not failures:
+        print("What this checker established: the record encodes a DENY admission")
+        print("decision and passed every check above. No property beyond those checks")
+        print("is asserted.")
+        print("Absence of an outcome receipt for this attempt_id is consistent with")
+        print("the action having been blocked before dispatch. It does not establish")
+        print("it. That needs two conditions this checker does not have: an")
+        print("authenticated commitment that the examined receipt set is complete for")
+        print("the window, and an execution profile under which every dispatch emits a")
+        print("receipt. Without the second, a complete set can be empty while an")
+        print("action ran by a path that emits nothing.")
+    else:
+        print("No property is asserted for a record whose checks did not pass.")
     print("attempt_id: %s" % rec.get("attempt_id"))
 
     # Honest, single exit code. Any named failure is exit 1; a full pass is exit 0.


### PR DESCRIPTION
Tightens the claim language on the example vector from #45, after a closer look at what a content-derived identifier actually establishes in a record that carries no signature.

The README said the checker "proves record integrity" and called the identifier the sole tamper-detection mechanism. Neither holds. A hash stored beside the fields it commits to detects accidental corruption, and detects alteration only for a verifier that holds the identifier from some source other than the record. Anyone who can rewrite the record can rewrite the identifier in the same stroke. The Claim boundary section now states what the checker does show and what it does not, including that absence of an outcome receipt does not by itself establish that nothing executed.

The correction could not stop at the README: `check.py` repeated the same overclaims and printed the absence claim on every record it checked. The checker now states the same boundary. The loader rejects duplicate property names and unpaired surrogates at load time, and rejects a non-object top-level value. Out-of-domain preimage values fail a named check and skip the identifier recompute. Input-derived text is JSON-escaped before printing, so no record value or receipt path can fabricate an additional output line; the exit code is the interface. The self-test runs ten cases. Each pins an exit code and named output and requires an empty stderr.

One addition beyond the correction. Reading `vector-ast09-outcome-pairing-integrity.json` from #46 made clear why the five-field and four-field derivations both fit the guidance wording: they are doing different jobs. A pairing key has to be recomputable by a party that does not know `policy_version`. The five-field derivation commits `agent_id`, `action_type`, `scope`, `policy_version`, and `timestamp_ms`. It does not commit `decision`, which is why the checker asserts the decision separately. That section now names the distinction and points at the fixture corpus for the pairing form.

Changes span `examples/ast09-execution-receipts/README.md` and `check.py`. The two JSON fixtures and `ast09.md` are unchanged. `ast09.md` still says absence of an outcome receipt proves the action was blocked; that overstates for the reason the Claim boundary section gives, and the correction deserves its own conversation rather than being folded in here. `validate.sh` passes. The checker exit contract is `0 valid / 1 failed check / 2 usage error`; `--selftest` returns 0 on pass. `validate.sh` does not currently run the self-test; I can wire that in as a follow-up if useful.
