### PR TITLE
docs(ast02,index): Bluebear Security slopsquatting evidence + mitigation

### DIFF
--- a/ast02.md
+++ b/ast02.md
@@ -24,6 +24,7 @@ The barrier to publishing on ClawHub was a `SKILL.md` file and a GitHub account 
 - **Dependency confusion**: a skill's `package.json` or `requirements.txt` pulls a typosquatted nested dependency containing the actual payload — the surface skill appears clean.
 - **Snyk-documented attack**: skill named "Summarize YouTube Videos" imports `yutube-dl-core` instead of a legitimate package; nested dependency installs a backdoor.
 - **Trail of Bits (Jun 3, 2026)**: public skill marketplaces (skills.sh, ClawHub) run a "ship-first, secure-later" model with one-click install and no meaningful vetting — and the scanners meant to backstop them were all bypassed in under an hour (see AST08). Their recommendation is the traditional supply-chain one: curate dependencies in an internal/approved marketplace, pin versions, and control who can publish or update — automated scanning cannot replace that.
+- **Bluebear Security, *Slopsquatting Through Missing Dependencies* (Jun 8, 2026)**: a scan of 45 repositories (69,520 combined stars) found 72 exported skills and plugins that reference packages which do not exist — 50 npm, 18 PyPI, 4 Cargo. The missing names appeared not only in dependency manifests but in README install instructions and setup scripts an agent or user may execute. Because the package is unregistered at review time, the skill scans clean; an attacker can later claim the name and every future install pulls attacker-controlled code without the original repository ever changing.
 - **Air Security, *The Story of Skills* (Jun 22, 2026)**: a researcher-built malicious skill entered a ~36K-star community plugin marketplace through an accepted pull request, inheriting its stars and credibility; promoted on social media, it reached over 26,000 agents — including corporate ones — while scanners, stars, and reputation all cleared it.
 - **Air Security, *The Circus of Skills* (Jun 24, 2026)**: a scan of 142,836 live skills found 17,822 (~12.4%, 6.7M installs) rest on at least one untrusted external resource — sketchy domains, zero-reputation GitHub repos, freshly published packages, free-tier hosts — each an unpinned dependency that can turn malicious without the skill itself changing.
 - **Air Security, *SkillJacking* (Jul 2, 2026)**: 925 skills serving ~134K agents sit on instantly hijackable sources — deleted GitHub accounts, unregistered packages, expired domains, freed cloud-app slots. Researchers took over the most popular video-generation skill on skills.sh (11,483 installs) by re-registering its deleted owner account; the marketplace listing kept its stars, trust, and installs.
@@ -55,6 +56,7 @@ Compromise a trusted skill author's account, push a backdoored version.
 5. **Scan recursive dependency trees**, not just top-level skill files.
 6. **Support an internal skill mirror / allowlist** for enterprise deployments.
 7. **Provide revocation infrastructure**: support revoking a compromised signing key (invalidating every skill signed with it), a single skill version by content digest, or an entire publisher; have hosts consult a revocation endpoint at load time and cache its state within a bounded freshness window.
+8. **Verify referenced packages actually exist before trusting them**: check that every dependency named in a skill's manifests, README install instructions, and setup scripts resolves to a *registered* package with legitimate history — at publish time and continuously. Hash-pinning (control 3) and dependency-tree scanning (control 5) cannot catch a package that does not exist yet, so an unregistered name is a slopsquatting slot an attacker can claim after the skill has already passed review; flag plausible names with no registry presence.
 
 ### Code Example: Dependency Pinning
 
@@ -182,6 +184,7 @@ Supply chain compromise indicators:
 - [Air Security: The Story of Skills](https://www.air.security/blog-posts/the-story-of-skills)
 - [Air Security: The Circus of Skills](https://www.air.security/blog-posts/the-circus-of-skills)
 - [Air Security: SkillJacking](https://www.air.security/blog-posts/skilljacking)
+- [Bluebear Security: Slopsquatting Through Missing Dependencies in Agent Skills and Plugins](https://bluebear.io/blog/agent-skills-plugins-slopsquatting/)
 
 ---
 

--- a/index.md
+++ b/index.md
@@ -202,6 +202,8 @@ The following is a condensed timeline of confirmed real-world incidents involvin
 
 - **Jun 3**: Trail of Bits publishes "The Sorry State of Skill Distribution" — every public skill scanner tested (ClawHub's VirusTotal + LLM guard model, Cisco's `skill-scanner`, the skills.sh scanners) is bypassed in under an hour, via payload padding that forces truncation, logic hidden in binary and archive formats, and prompt-injecting the scanner's own LLM judge.
 
+- **Jun 8**: Bluebear Security publishes "Slopsquatting Through Missing Dependencies" — a scan of 45 repositories (69,520 combined stars) finds 72 exported skills and plugins referencing packages that do not exist (50 npm, 18 PyPI, 4 Cargo), named in dependency manifests, README install instructions, and setup scripts; each unregistered name is a slot an attacker can claim so future installs pull attacker-controlled code without the skill ever changing.
+
 - **Jun 22–24**: Air Security publishes "The Story of Skills" and "The Circus of Skills" — a researcher-built malicious skill reaches over 26,000 agents while every scanner clears it, its payload served from an attacker-controlled external documentation URL; a follow-up scan of 142,836 live skills finds 17,822 (12.4%, 6.7M installs) resting on at least one untrusted external instruction source.
 
 ### July 2026
@@ -522,6 +524,7 @@ changelog:
 - **SecurityScorecard** (Feb 2026) — 135,000+ OpenClaw instances publicly exposed; 53,000+ correlated with prior breach activity.
 - **Snyk: 280+ Leaky Skills** (Feb 5, 2026) — API key and PII exposure across ClawHub.
 - **Snyk: Why Your Skill Scanner Is Just False Security** (Feb 11, 2026) — Pattern-matching scanner limitations.
+- **Bluebear Security: Slopsquatting Through Missing Dependencies** (Jun 8, 2026) — 72 skills and plugins across 45 repositories reference nonexistent npm/PyPI/Cargo packages, named in manifests, READMEs, and setup scripts; unregistered names are open slots for attacker-controlled code.
 - **Air Security: The Story of Skills** (Jun 22, 2026) — Researcher-built malicious skill reached 26,000+ agents via a trusted marketplace and social media; every scanner cleared it.
 - **Air Security: The Circus of Skills** (Jun 24, 2026) — 142,836 skills scanned for untrusted external instruction sources; 17,822 (12.4%, 6.7M installs) affected.
 - **Air Security: SkillJacking** (Jul 2, 2026) — 925 skills resting on instantly hijackable dependencies (~134K agents); top skills.sh video-generation skill taken over via a deleted GitHub account.


### PR DESCRIPTION
Grounds **AST02 — Supply Chain Compromise** with Bluebear Security's [*Slopsquatting Through Missing Dependencies*](https://bluebear.io/blog/agent-skills-plugins-slopsquatting/) (2026-06-08).

**Why AST02:** trust in a skill, repository, or marketplace implicitly extends to the external packages named in its executable documentation and setup instructions. Bluebear Security found 72 exported skills and plugins across 45 repositories (69,520 combined stars) referencing packages that do not exist — 50 npm, 18 PyPI, 4 Cargo — in dependency manifests, README install instructions, and setup scripts. Unlike a conventional malicious-package incident, the package may not exist when the skill is reviewed: the skill scans clean, and an attacker can later claim the unregistered name so future installs retrieve attacker-controlled code without the original repository ever changing. This exploits the transitive trust boundary, which hash-pinning and dependency-tree scanning cannot close for a package that does not exist to pin or resolve.

**Changes**
- `ast02.md`: Real-World Evidence bullet, one Preventive Mitigation (verify referenced packages actually exist, at publish time and continuously), reference.
- `index.md`: Incident Timeline (Jun 8) and Key Research entries, matching the format used for every other cited research post.

All claims verified against the source. `validate.sh` passes.