### PR TITLE
docs(scanner-integration): pin the digest basis to raw octets

### DIFF
--- a/skill-scanner-integration.md
+++ b/skill-scanner-integration.md
@@ -394,12 +394,14 @@ No single scanner covers every AST10 risk: a drift detector flags that a skill's
 
 The SARIF `artifacts[]` + `hashes` mechanism makes this deterministic. A scanner that emits a content digest for each scanned file lets a consumer (a registry, a PR bot, a dashboard) join findings from independent tools on that digest:
 
-- `run.artifacts[]` — one entry per scanned file, each carrying `location.uri` and `hashes["sha-256"]` (bare lowercase 64-char hex of the file bytes). The SHA-256 is the **join key**: two reports describe the same artifact iff their digests match.
+- `run.artifacts[]` — one entry per scanned file, each carrying `location.uri` and `hashes["sha-256"]` (bare lowercase 64-char hex over the file's **raw octets**, taken before any character decoding, so it equals `sha256sum` of the file). The SHA-256 is the **join key**: two reports describe the same artifact iff their digests match.
 - `result … physicalLocation.artifactLocation.index` — every finding points into `artifacts[]`, so it resolves to the exact bytes it was raised against and self-invalidates when the file changes.
 - `result.properties.layer` — a short string naming the class of scanner that produced the finding (e.g. `drift`, `content`, `atr`), so merged findings stay attributable. Consumers should treat an unknown layer as opaque rather than dropping the finding.
 - `run.tool.driver.name` + `version` — provenance, so a merged report records which tool and version produced each layer.
 
 A consumer merges N reports by grouping `artifacts[]` across runs on `hashes["sha-256"]`, attaching each run's results via `artifactLocation.index`, and partitioning by `layer` — no content re-hashing and no coordination between the tools.
+
+The "raw octets" qualifier carries weight out of proportion to its length. A scanner that reads its input as text and hashes the decoded string agrees with `sha256sum` on every well-formed UTF-8 file, so the divergence is invisible in ordinary testing — including against ASCII, multi-byte text, and a BOM. But decoding substitutes U+FFFD for each invalid sequence *before* hashing, and that substitution is many-to-one: two files differing only in their invalid bytes collapse to a single digest. A clean verdict on one then replays as authoritative for the other, and the join **succeeds** rather than failing loudly. Testing this requires a fixture built for it — one file carrying a lone continuation byte and a WTF-8-encoded lone surrogate — because every well-formed sample passes under either reading.
 
 ```json
 {


### PR DESCRIPTION
## What

One qualifier on the join key: the artifact SHA-256 is taken over the file's **raw octets, before any character decoding**, so it equals `sha256sum` of the file. Plus a short paragraph on why that phrasing is load-bearing and what it takes to test.

Docs-only, +3/-1. No change to the join shape, the `layer` convention, or any fixture schema.

## Why "file bytes" isn't quite enough

This isn't hypothetical. When four scanners implemented this join shape, two of them hashed the file's raw buffer and two hashed a UTF-8-decoded string — and nobody noticed, because **the two bases agree on every well-formed UTF-8 file**, including ASCII, multi-byte text, and a BOM. `readFileSync(path, 'utf8')` followed by a hash looks exactly like "hashing the file bytes" to the person writing it.

The divergence appears only on invalid UTF-8 and lone surrogates, where decoding replaces each invalid sequence with U+FFFD before hashing. That substitution is **many-to-one**, which makes the failure mode worse than a mismatch: two files differing only in their invalid bytes collapse to one digest, so a clean verdict on one replays as authoritative for the other and the join *succeeds*. Nothing surfaces it.

Measured on a purpose-built fixture (one file with a lone `0x80` continuation byte and a WTF-8-encoded lone surrogate `ED A0 80`):

| basis | digest |
|---|---|
| raw octets (`sha256sum`) | `0e5f6446…613d365b` |
| decode-then-hash | `eec1f132…57808c1d` |
| **same file, lone byte flipped `0x80`→`0x81`** | raw `1546f3f1…` / **string digest unchanged at `eec1f132…`** |

That last row is the collision: a different file, an identical digest.

## Provenance

The wording here is the one adopted as normative in the multi-scanner envelope RFC ([claude-code-skill-security-check#24](https://github.com/aliksir/claude-code-skill-security-check/issues/24)) after the four-implementation audit in [anthropics/skills#492](https://github.com/anthropics/skills/issues/492), where the divergence was found and the discriminating fixture built. The two implementations that were on the string basis (Agent Threat Rules and prompt-defense-audit) have since moved to raw octets, so all four now join correctly on invalid input, not just on well-formed input.

Worth noting for anyone verifying this page: the example digest at line 412, `64f9e18e…ec3395a`, is the SHA-256 of the `drifted/SKILL.md` fixture from that same cross-tool exercise ([skills-lock/skil-lock](https://github.com/skills-lock/skil-lock) `examples/drift-demo/`). It is well-formed UTF-8, so it is identical under either basis — which is precisely why it could not have caught this.

## Relationship to #49

Complementary, no overlap. #49 defines what a merged view *means* once artifacts are joined (a missing or truncated layer must not read as clean evidence). This defines what makes two artifacts *the same artifact* in the first place. Both are boundary conditions on the same mechanism; either can land without the other.

## Verification

`bash validate.sh` → all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)