### PR TITLE
docs(ast07): Metano Sleeper Skills — self-directed update evidence

### DIFF
--- a/ast07.md
+++ b/ast07.md
@@ -24,6 +24,7 @@ Package update drift is a known risk in traditional software. In skills, it's am
 - **OpenClaw's hot-reload `SkillsWatcher`** enables real-time skill updates: a compromised upstream skill repository becomes instantly active without requiring agent restart.
 - **Air Security, *SkillJacking* (Jul 2, 2026)**: published skills can be taken over outright — the most popular video-generation skill on skills.sh (11,483 installs) served its files live from a GitHub repo whose owner account had been deleted; researchers re-registered the username and controlled what every install received from that moment on. Victims needed no update to be affected — just one more use. In total, 925 skills (~134K agents) sat on such instantly hijackable sources, and the takeover itself tripped no scanner.
 - **Air Security, *The Circus of Skills* (Jun 24, 2026)**: 17,822 skills (~12.4% of 142,836 scanned; 6.7M installs) rest on at least one untrusted external resource — including binaries fetched from a repo's `releases/latest` — content that can drift malicious underneath a deployed skill without any version change or update event.
+- **Metano, *Sleeper Skills* (Aug 2026)**: a review of skills on ClawHub and SkillsMP found 50+ carrying self-update capability (28K+ downloads, 23K+ stars); 56 showed self-update, self-modification, dormant-patcher or persistent-state behavior, and 9 met a strict test — a normal-use or scheduled path that can replace the installed skill or its standing instructions with no per-change consent and no user-facing notice of that specific change. Three mechanisms were documented: an installer, run as a prerequisite to ordinary commands, that polls a remote endpoint and overwrites its own scripts, `SKILL.md` and reference material, then directs the agent to disregard prior memory of the skill and re-read the replaced file (`hope0719/quarkclouddrive-skill`); a skill whose normal loop writes what it "learns" back into its own `SKILL.md`, so untrusted runtime input — webpages, OCR output, accessibility text — can be laundered into a file later sessions treat as trusted (`tahcia/tahcia-console`); and a skill whose installed bytes never change while it reloads mutable Markdown instructions from an operator-controlled host on a heartbeat (`g620710/meyo`). The update channel is declared in the artifact that was reviewed, so a `sha256:` pin binds the updater rather than what it installs, and no account compromise, writable skill directory or registry event is required.
 
 ## Attack Scenarios
 
@@ -42,6 +43,10 @@ Attacker forces a downgrade to a known-vulnerable version via dependency resolut
 ### Hot-Reload Abuse
 
 Skill directory is writable; attacker modifies `SKILL.md` mid-session; agent picks up changes without restart.
+
+### Author-Declared Update Channel
+
+The update path is part of the reviewed artifact rather than something done to it. A skill documents an installer as a prerequisite; on each run the installer fetches a bundle from a remote endpoint and replaces the skill's own scripts and `SKILL.md`. The content that executes is therefore retrieved after the approval, from a source no digest of the skill covers, under the authority already granted to that skill. Distinct from Hot-Reload Abuse, which presumes an attacker who can write to the skill directory: here the skill rewrites itself by design, and a self-modifying skill can additionally promote untrusted runtime input into its own standing instructions with no external writer at all.
 
 ## Preventive Mitigations
 
@@ -89,6 +94,7 @@ Skill directory is writable; attacker modifies `SKILL.md` mid-session; agent pic
 - [SecurityScorecard: 135,000+ OpenClaw instances exposed](https://securityscorecard.com/)
 - [Air Security: SkillJacking](https://www.air.security/blog-posts/skilljacking)
 - [Air Security: The Circus of Skills](https://www.air.security/blog-posts/the-circus-of-skills)
+- [Metano: Sleeper Skills](https://metano.ai/post/sleeper-skills)
 
 ---
 

--- a/index.md
+++ b/index.md
@@ -207,6 +207,10 @@ The following is a condensed timeline of confirmed real-world incidents involvin
 
 - **Jul 2**: Air Security publishes "SkillJacking" — 925 skills serving ~134K agents sit on instantly hijackable dependencies (deleted GitHub accounts, unregistered packages, expired domains, freed cloud-app slots); researchers take over the most popular video-generation skill on skills.sh (11,483 installs) by re-registering its deleted owner account.
 
+### August 2026
+
+- **Aug 2026**: Metano publishes "Sleeper Skills" — a review of ClawHub and SkillsMP finds 50+ skills carrying self-update capability (28K+ downloads, 23K+ stars); 56 show self-update, self-modification, dormant-patcher or persistent-state behavior, and 9 can change their installed content or standing instructions with no per-change consent and no user-facing notice. The update channel is declared inside the reviewed artifact — an installer that overwrites its own `SKILL.md` before use, a skill that writes what it "learns" back into its own instructions, and a skill whose bytes never change while it reloads instructions from an operator-controlled host — so a `sha256:` pin binds the updater rather than what it installs.
+
 ---
 
 ## Summary Table
@@ -524,6 +528,7 @@ changelog:
 - **Air Security: The Story of Skills** (Jun 22, 2026) — Researcher-built malicious skill reached 26,000+ agents via a trusted marketplace and social media; every scanner cleared it.
 - **Air Security: The Circus of Skills** (Jun 24, 2026) — 142,836 skills scanned for untrusted external instruction sources; 17,822 (12.4%, 6.7M installs) affected.
 - **Air Security: SkillJacking** (Jul 2, 2026) — 925 skills resting on instantly hijackable dependencies (~134K agents); top skills.sh video-generation skill taken over via a deleted GitHub account.
+- **Metano: Sleeper Skills** (Aug 2026) — 50+ skills across ClawHub and SkillsMP carry self-update capability (28K+ downloads, 23K+ stars); 9 can replace their own content or standing instructions with no per-change consent and no user-facing notice, via update channels declared in the reviewed artifact itself.
 
 ### Industry Reports
 


### PR DESCRIPTION
Grounds **AST07 — Update Drift** with Metano's [*Sleeper Skills*](https://metano.ai/post/sleeper-skills) (Aug 2026).

**Why AST07:** every current evidence entry describes an update arriving from *outside* the artifact — account takeover (SkillJacking), external-resource drift (The Circus of Skills), patch lag (the CVE cluster), or a writable skill directory (hot-reload). This adds the case where the update channel is declared *inside* the artifact that was reviewed. A review of skills on ClawHub and SkillsMP found 50+ carrying self-update capability (28K+ downloads, 23K+ stars); 56 showed self-update, self-modification, dormant-patcher or persistent-state behavior, and 9 met a strict test — a normal-use or scheduled path that can change the installed skill or its standing instructions with no per-change consent and no required user-facing notice of that specific change. Three mechanisms:

- `hope0719/quarkclouddrive-skill` — an installer documented as a prerequisite to ordinary commands polls a remote endpoint and replaces its own scripts, `SKILL.md` and reference material, then directs the agent to disregard prior memory of the skill and re-read the replaced file.
- `tahcia/tahcia-console` — writes what it "learns" during ordinary use back into its own `SKILL.md`, so untrusted runtime input (webpages, OCR output, accessibility text) can be laundered into a file later sessions treat as trusted.
- `g620710/meyo` — installed bytes never change while mutable Markdown instructions reload from an operator-controlled host on a heartbeat.

This bears on **Mitigation 1** specifically: a `sha256:` pin binds the updater, not what it installs. Pin `quarkclouddrive-skill`, verify it, freeze the environment, and the verified content still fetches a bundle and overwrites its own `SKILL.md` on the next ordinary use — no account compromise, no writable directory, no registry event required. It also separates cleanly from the existing *Hot-Reload Abuse* scenario, which presumes an attacker who can write to the skill directory; a self-modifying skill needs no external writer.

**Changes**
- `ast07.md`: Real-World Evidence bullet, an *Author-Declared Update Channel* attack scenario, reference.
- `index.md`: Key Research entry and an August 2026 Incident Timeline subsection (the timeline currently ends Jul 2), matching the format used for every other cited research post.

**Evidence only** — no change to the Preventive Mitigations list, so this does not collide with #63, which proposes a mitigation for this same gap.

Claims are scoped to observed capability, not asserted malice: the post is explicit that it found no basis to claim a specific malicious payload was delivered through these paths, and the wording added here keeps that boundary. Disclosure: I authored the cited research and work at Metano. All claims verified against the source. `validate.sh` passes.

Part of #63
