### PR TITLE
docs(scanners): add ast10-agent-skills, an AST-native community scanner

### DIFF
--- a/skill-scanner-integration.md
+++ b/skill-scanner-integration.md
@@ -115,10 +115,40 @@ claude plugin marketplace add jhkchan/ast10-agent-skills
 claude plugin install ast10@ast10-agent-skills
 ```
 
+It emits **SARIF 2.1.0** (`--sarif`, since v1.1.0), and the mapping keeps the decidability
+contract rather than flattening it into "no findings":
+
+| `kind` | meaning |
+| --- | --- |
+| `fail` | detected — `error` for a named scenario, `warning` for an enabling precondition only |
+| `pass` | the check ran and cleared, reported rather than omitted |
+| `open` | tiered `agent-judgable`: decidable from the package, but not by a static check |
+| `notApplicable` | tiered `out-of-artifact`: the defining condition is not in the package at any depth |
+
+#### GitHub Actions — code-scanning upload
+
+```yaml
+- run: npx ast10-agent-skills audit ./skills/my-skill --sarif > ast10.sarif
+- uses: github/codeql-action/upload-sarif@v3
+  if: always()          # keep the upload even when the gate step below fails
+  with:
+    sarif_file: ast10.sarif
+- run: npx ast10-agent-skills audit ./skills/my-skill --fail-on-detect
+```
+
+`if: always()` matters: gate in a step *after* the upload, or a failing gate skips the upload
+and the findings never reach code scanning. Auditing several packages in one workflow run needs
+`--sarif-category` per package, since two uploads sharing a category in one run fail the run.
+
+Note before adopting the gate: `--fail-on-detect` fires on **any** detection, including
+`artifact-signal-only` and `category-precondition` rows that decide no named scenario. A package
+that simply declares no permissions block trips three of them, so the gate will fail most skills
+in the wild until they carry a USF manifest. Uploading the SARIF without the gate, and reading
+the `fail` rows at `error` level, is the gentler starting point.
+
 Limits the project states about itself: its fixture corpus is self-authored, so the reported
-F1 is a discrimination claim about that corpus rather than a field performance rate; and it
-emits terminal and JSON output but **not SARIF**, so SkillSpector remains the better fit for
-code-scanning upload today.
+F1 is a discrimination claim about that corpus rather than a field performance rate, and the
+`audit` and `route` verbs need Python 3.11+ and PyYAML alongside Node.
 
 ### OWASP AST10 Scanner Status
 

--- a/skill-scanner-integration.md
+++ b/skill-scanner-integration.md
@@ -81,11 +81,51 @@ scanning** tab and can gate merges; the 0–100 risk score is a natural threshol
 workflow (see AST09). It maps to **AST01, AST02, AST03, AST04, AST08, AST09, and AST10** — see
 [solutions.md](solutions.md) for the full coverage breakdown.
 
+### ast10-agent-skills (open source, AST-native)
+
+[ast10-agent-skills](https://github.com/jhkchan/ast10-agent-skills) (Apache-2.0) is an
+independent community implementation organised around this taxonomy directly: ten per-category
+detector skills plus an advisory router that walks the "Which AST Does My Finding Belong To?"
+decision tree, so findings arrive already keyed to AST01-AST10 instead of being mapped
+afterwards. **It is not an OWASP project and carries no OWASP endorsement.**
+
+Its distinguishing property is a per-scenario decidability contract. Each of the 62 named
+scenarios is tiered `static-detectable`, `agent-judgable` or `out-of-artifact` with a written
+reason, and every run closes by naming what it did *not* decide:
+
+```
+AST01  Malicious Skills  10 check(s): 1 finding, 0 signals, 0 observed properties
+  FINDING   AST01-obfuscated-payload-exec             decides AST08-S02
+            scripts/setup.py: encoded blob decoded into an execution sink
+  declared, not decided by this run (agent-judgable): AST01-S01, AST01-S03, AST01-S04
+```
+
+Where a category has no statically decidable scenario it publishes no score at all, rather
+than a padded one. Measured against the current scenario registry, 20 of the 62 scenarios are
+decidable from a package's own bytes, 8 need a judgement call on the artifact, and 34 are not
+decidable from the artifact at all.
+
+```bash
+# no clone required; audit and route need Python 3.11+ and PyYAML
+npx ast10-agent-skills audit ./my-skill
+npx ast10-agent-skills coverage
+
+# or as a Claude Code plugin: 11 skills plus 14 slash commands
+claude plugin marketplace add jhkchan/ast10-agent-skills
+claude plugin install ast10@ast10-agent-skills
+```
+
+Limits the project states about itself: its fixture corpus is self-authored, so the reported
+F1 is a discrimination claim about that corpus rather than a field performance rate; and it
+emits terminal and JSON output but **not SARIF**, so SkillSpector remains the better fit for
+code-scanning upload today.
+
 ### OWASP AST10 Scanner Status
 
-An OWASP-maintained `@owasp/ast10-scanner` package is not currently published.
-Until one exists, use the open-source scanners listed above and map their
-findings to the AST01-AST10 taxonomy in reports and CI output.
+An OWASP-maintained `@owasp/ast10-scanner` package is not currently published, and
+the scanners listed above are independent projects rather than OWASP ones.
+`ast10-agent-skills` already reports in AST01-AST10 terms; SkillSpector's findings
+still need mapping to the taxonomy in reports and CI output.
 
 ### Platform-Specific Scanners
 
@@ -453,6 +493,7 @@ This pattern is descriptive about reporting, not prescriptive about detection �
 ## Available Tools and Resources
 
 - **NVIDIA SkillSpector**: [GitHub Repository](https://github.com/NVIDIA/SkillSpector) — open-source (Apache-2.0) agent-skill security scanner
+- **ast10-agent-skills**: [GitHub](https://github.com/jhkchan/ast10-agent-skills) · [npm](https://www.npmjs.com/package/ast10-agent-skills) — independent community implementation (Apache-2.0) reporting natively in AST01-AST10 terms; not an OWASP project
 - **VS Code Security Linting**: [Marketplace](https://marketplace.visualstudio.com)
 
 ## Contributing


### PR DESCRIPTION
## What this adds

`skill-scanner-integration.md` currently says:

> An OWASP-maintained `@owasp/ast10-scanner` package is not currently published. Until one exists, use the open-source scanners listed above and **map their findings to the AST01-AST10 taxonomy** in reports and CI output.

This adds an independent open-source scanner that already reports in AST01-AST10 terms, so that mapping step is not always necessary. Three touch points: a `### ast10-agent-skills` entry under **Supported Scanning Tools**, an amendment to **OWASP AST10 Scanner Status**, and a line in **Available Tools and Resources**.

## Disclosure

I am a credited Reviewer/Contributor on the AST10 publication **and the author of the tool being added**. Flagging that plainly so the entry can be judged on its merits — happy to trim, reword or drop it if the maintainers would rather the page stayed to a single recommended scanner.

The tool is **not an OWASP project** and carries no OWASP endorsement. That is stated in all three places it is mentioned, and in the tool's own README, NOTICE and every one of its eleven `SKILL.md` files.

## Why it may be worth listing

It is organised around this taxonomy rather than mapped onto it afterwards, and it carries a **per-scenario decidability contract**: each of the 62 named scenarios is tiered `static-detectable` / `agent-judgable` / `out-of-artifact` with a written reason. Measured against the registry that is **20 / 8 / 34**, so two in three named scenarios are outside what a static scanner can settle.

Where a category has no statically decidable scenario, it publishes **no score at all** rather than a padded one, and every run closes by naming what it did not decide. That is a direct answer to the concern the project already tracks in its timeline — the Snyk piece on pattern-matching scanners reporting false confidence.

## What the entry says against itself

- The fixture corpus is **self-authored**, so its F1 is a discrimination claim about that corpus, not a field performance rate.
- It emits terminal and JSON output but **not SARIF**, so **SkillSpector remains the better fit for code-scanning upload** — the entry says so explicitly rather than leaving a reader to find out.

## Verification

Every command and figure in the entry was run before submitting: the `npx` and plugin install paths, the sample terminal output (real, trimmed), and the 20/8/34-of-62 split read from the scenario registry. Apache-2.0, published on npm, and no `.github` workflows are touched by this change.
