### PR TITLE
docs(ast07): add Preventive Mitigation 7, re-evaluate loaded state at invocation (closes #63)

### DIFF
--- a/ast07.md
+++ b/ast07.md
@@ -13,6 +13,8 @@ type: documentation
 
 Skills are installed and forgotten. Without immutable pinning and automated update verification, deployed skills drift out of sync with known-good versions — either because patches are not applied (leaving known vulnerabilities open) or because auto-update mechanisms blindly apply upstream changes that may themselves be malicious.
 
+Drift also occurs with no update at all. Content a skill resolves at runtime can change while the pinned skill does not, and an authorization granted earlier can still be standing after the content it was granted against has moved. The consequence is not uniform. Where the authorized action is read-only or reversible, re-running under changed content is recoverable. Where it is irreversible, an approval given over one version cannot carry to another, because what executes is not what was approved.
+
 ## Why It's Unique to Skills
 
 Package update drift is a known risk in traditional software. In skills, it's amplified by two factors: (1) skills are often installed by individuals without enterprise patch management, and (2) a "fix" version of a skill is itself unverifiable without cryptographic pinning — the attacker can push a "v1.0.1" that looks like a patch but contains a new payload.
@@ -51,6 +53,7 @@ Skill directory is writable; attacker modifies `SKILL.md` mid-session; agent pic
 4. **Subscribe to registry security advisories** and auto-alert on CVE matches for installed skills.
 5. **Enforce a human-in-the-loop approval step** for any skill update in enterprise environments.
 6. **Maintain an inventory of installed skills** with version, hash, and last-verified timestamp.
+7. **Re-evaluate the loaded state at invocation, not only at update.** Record the content hash of the skill and of every external resource it resolves, at every read of the instruction surface rather than once at install. Where an action was authorized against a recorded state, a change in that state invalidates the authorization and requires a fresh one before execution.
 
 ## OWASP Mapping
 

--- a/ast07.md
+++ b/ast07.md
@@ -53,7 +53,7 @@ Skill directory is writable; attacker modifies `SKILL.md` mid-session; agent pic
 4. **Subscribe to registry security advisories** and auto-alert on CVE matches for installed skills.
 5. **Enforce a human-in-the-loop approval step** for any skill update in enterprise environments.
 6. **Maintain an inventory of installed skills** with version, hash, and last-verified timestamp.
-7. **Re-evaluate the loaded state at invocation, not only at update.** Record the content hash of the skill and of every external resource it resolves, at every read of the instruction surface rather than once at install. Where an action was authorized against a recorded state, a change in that state invalidates the authorization and requires a fresh one before execution.
+7. **Re-evaluate the loaded state at invocation, not only at update.** Record the content hash of the skill and of every external resource it resolves, at every read of the instruction surface rather than once at install. Where an action was authorized against a recorded state, any later divergence from the state recorded at the time of that authorization invalidates it and requires a fresh one before execution, whether the divergence arrived through an update or without one.
 
 ## OWASP Mapping
 


### PR DESCRIPTION
## Description
Adds Preventive Mitigation 7 to AST07 and a scoping paragraph to its Description. Implements the proposal in #63 after review by @harshakshit, @ossumpossum and @JosephDoUrden.

## Type of Change
- [x] Security enhancement
- [x] Documentation update

## Changes Made
- `ast07.md`, Description: one paragraph noting that drift also occurs with no update, and that the consequence differs by whether the authorized action is reversible.
- `ast07.md`, Preventive Mitigations: new item 7, re-evaluate the loaded state at invocation rather than only at update.
- No other files. Three added lines, plus a trailing-newline normalisation on the final line introduced by the GitHub web editor.

## AST Impact
- **AST Numbers Affected**: AST07, cross-references AST05
- **Risk Areas**: Update Drift, Untrusted External Instructions, Supply Chain
- **Severity Changes**: None. Severity stays Medium.

## Testing
- [x] Changes build successfully (Jekyll) — Markdown only, no front-matter or layout change
- [x] Links are valid and functional — no links added
- [x] Markdown formatting is correct
- [x] Cross-references are accurate — AST05 reference unchanged and still accurate
- [x] No broken internal links

## Security Considerations
- [x] No sensitive information exposed
- [x] References to real vulnerabilities are properly cited
- [x] No active exploit code included
- [x] Risk assessments are accurate and evidence-based

## Documentation Updates
- [x] README.md updated if necessary — not necessary
- [x] Table of contents reflects changes — no headings added
- [x] Cross-references between AST files are maintained
- [ ] Index page summary table updated

The index checkbox is deliberately unticked. `index.md` lists AST07's Key Mitigation as "Immutable pinning, hash verification", which mitigation 7 argues is insufficient on its own, so there is a case for revising that cell. Left untouched here to keep this diff to one file and avoid colliding with the open PRs against `index.md`. Happy to follow up separately if maintainers want it changed.

## Notes for reviewers

The two negative test cases from #63 are not included, because AST07 has no testing section and adding one would be a structural change beyond this proposal.

@JosephDoUrden offered in #63 to draft the hosted-MCP case into the evidence and testing sections once this text and #66 land. Nothing here pre-empts that, and the mitigation as written already covers the class he raised: a definition served at connection time has no artifact to pin, so re-evaluation keyed to the read is the only instant that reaches it.